### PR TITLE
Typo in "Sentinel Restituted"

### DIFF
--- a/s1tbx-io/src/main/java/org/esa/s1tbx/dataio/orbits/SentinelPODOrbitFile.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/dataio/orbits/SentinelPODOrbitFile.java
@@ -59,7 +59,7 @@ public class SentinelPODOrbitFile extends BaseOrbitFile implements OrbitFile {
     // 4) POE
     // 5) NRT Restituted
 
-    public final static String RESTITUTED = "Sentinel Restituded";
+    public final static String RESTITUTED = "Sentinel Restituted";
     public final static String PRECISE = "Sentinel Precise";
 
     private final int polyDegree;


### PR DESCRIPTION
Just a super minor typo fix.
This typo caused a moment of confusion for me when I edited a graph manually and the Apply-Orbit-File still kept downloading Precise orbits.