### PR TITLE
TanDEM-X geocoding-related fixes

### DIFF
--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/terrasarx/TerraSarXProductDirectory.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/terrasarx/TerraSarXProductDirectory.java
@@ -60,8 +60,8 @@ import java.util.Set;
  */
 public class TerraSarXProductDirectory extends XMLProductDirectory {
 
-    private static String TERRA_SAR_X = "TerraSar-X";
-    private static String TAN_DEM_X = "TanDem-X";
+    private static String TERRA_SAR_X = "TerraSAR-X";
+    private static String TAN_DEM_X = "TanDEM-X";
 
     private final File headerFile;
     private String productName = null;

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/terrasarx/TerraSarXProductDirectory.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/terrasarx/TerraSarXProductDirectory.java
@@ -1027,7 +1027,7 @@ public class TerraSarXProductDirectory extends XMLProductDirectory {
                 masterBands = appendIfMatch(imaginaryBand, "mst", masterBands);
                 slaveBands = appendIfMatch(imaginaryBand, "slv", slaveBands);
 
-                ReaderUtils.createVirtualIntensityBand(product, realBand, imaginaryBand, '_' + pol + extraInfo);
+                ReaderUtils.createVirtualIntensityBand(product, realBand, imaginaryBand, "");
 
                 try {
                     cosarBandMap.put(realBand.getName(), FileImageInputStreamExtImpl.createInputStream(file));

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/terrasarx/TerraSarXProductDirectory.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/terrasarx/TerraSarXProductDirectory.java
@@ -615,8 +615,14 @@ public class TerraSarXProductDirectory extends XMLProductDirectory {
 
     @Override
     protected void addGeoCoding(final Product product) {
-
-        final File georefFile = new File(getBaseDir(), "ANNOTATION" + File.separator + "GEOREF.xml");
+        File level1ProductDir = getBaseDir();
+        if (getHeaderFileName().startsWith("TDM")) {
+            // Using the master product is important here.
+            // The slave product is coregistered to the master without its geocoding being updated afterwards.
+            // Its geocoding is unusable because of this.
+            level1ProductDir = new File(getBaseDir(), masterProductName);
+        }
+        File georefFile = new File(level1ProductDir, "ANNOTATION" + File.separator + "GEOREF.xml");
         if (georefFile.exists()) {
             try {
                 //readGeoRef(product, georefFile);

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/terrasarx/TerraSarXProductDirectory.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/terrasarx/TerraSarXProductDirectory.java
@@ -625,8 +625,8 @@ public class TerraSarXProductDirectory extends XMLProductDirectory {
         File georefFile = new File(level1ProductDir, "ANNOTATION" + File.separator + "GEOREF.xml");
         if (georefFile.exists()) {
             try {
-                //readGeoRef(product, georefFile);
-                //return;
+                readGeoRef(product, georefFile);
+                return;
             } catch (Exception e) {
                 //
             }


### PR DESCRIPTION
Hi,

I experience geocoding errors of about 100 m with the existing CoSSC code, so I fixed some TanDEM-X CoSSC product geocoding peculiarities that were not accounted for in the code. 

I updated the CoSSC code to pick correct master from the metadata and then used the master SSC to get the overall geocoding. I also re-introduced the parsing of GEOREF.xml metadata file, which was commented out for some reason. Are there any issues in that code that block it from being used? The only explanation I could find was the commit message (53c7801cfbc43952110fa46249b80e1d4514290e) removing that bit of code that says "fix tsx reader for MGD tiepoints".

Picking the correct master image above is important because only the geocoding (and other metadata) in the master product is correct. The slave image in a CoSSC is coregistered to the master during product generation and its metadata is not updated to reflect that. [1]

[1] [TD-GS-PS-3028 TanDEM-X Experimental Product Description 1.2](https://tandemx-science.dlr.de/pdfs/TD-GS-PS-3028_TanDEM-X-Experimental-Product-Description_1.2.pdf), section "6.3.5 Data Components", p. 37

Best wishes,
Martin