### PR TITLE
Allow WarpOp to work when band units are not set

### DIFF
--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/GCPSelectionOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/GCPSelectionOp.java
@@ -348,6 +348,9 @@ public class GCPSelectionOp extends Operator {
                     if (unit != null && !unit.contains(Unit.IMAGINARY)) {
                         slvBand1 = slvBand;
                         break;
+                    } else if (unit == null) {
+                        // Assume that the image is real-valued if no unit is set
+                        slvBand1 = slvBand;
                     }
                 }
             }
@@ -366,7 +369,7 @@ public class GCPSelectionOp extends Operator {
                 targetBand.setSourceImage(srcBand.getSourceImage());
             } else {
                 final String unit = srcBand.getUnit();
-                if (oneSlaveProcessed == false && unit != null && !unit.contains(Unit.IMAGINARY)) {
+                if (!oneSlaveProcessed && (unit == null || !unit.contains(Unit.IMAGINARY))) {
                     oneSlaveProcessed = true;
                     primarySlaveBand = srcBand;
                     final MetadataElement absRoot = AbstractMetadata.getAbstractedMetadata(targetProduct);


### PR DESCRIPTION
Currently, when trying to coregister bands/images that do not have the unit property set, the coregistration fails to start because in such case the GCPSelectionOp does not set the "processed_slave" metadata required in WarpOp. Checking the value of the unit is only done to see if the image is complex. I think it is safe to assume that the image is real-valued by default when no unit is set and modified the code accordingly.

This is relevant when using SNAP to coregister images that lack some or all metadata, e.g. ones generated outside the SNAP environment.