### PR TITLE
JAI warp coefficients missing in WarpOp when master-slave are already perfectly aligned

### DIFF
--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/WarpOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/WarpOp.java
@@ -976,6 +976,11 @@ public class WarpOp extends Operator {
         pb1.add(DataBuffer.TYPE_FLOAT);
         final RenderedImage srcImageFloat = JAI.create("format", pb1);
 
+        if (warp == null) {
+            // no need to warp, images are already perfectly aligned
+            return (RenderedOp) srcImageFloat;
+        }
+
         // get warped image
         final ParameterBlock pb2 = new ParameterBlock();
         pb2.addSource(srcImageFloat);

--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/WarpOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/WarpOp.java
@@ -1037,63 +1037,22 @@ public class WarpOp extends Operator {
                 sum += Math.abs(slaveGCPCoords[i] - masterGCPCoords[i]);
             }
             if (sum < 0.01) {
-                switch (warpPolynomialOrder) {
-                    case 1: {
-                        xCoef = new double[3];
-                        yCoef = new double[3];
-                        xCoef[0] = 0;
-                        xCoef[1] = 1;
-                        xCoef[2] = 0;
-                        yCoef[0] = 0;
-                        yCoef[1] = 0;
-                        yCoef[2] = 1;
-                        break;
-                    }
-                    case 2: {
-                        xCoef = new double[6];
-                        yCoef = new double[6];
-                        xCoef[0] = 0;
-                        xCoef[1] = 1;
-                        xCoef[2] = 0;
-                        xCoef[3] = 0;
-                        xCoef[4] = 0;
-                        xCoef[5] = 0;
-                        yCoef[0] = 0;
-                        yCoef[1] = 0;
-                        yCoef[2] = 1;
-                        yCoef[3] = 0;
-                        yCoef[4] = 0;
-                        yCoef[5] = 0;
-                        break;
-                    }
-                    case 3: {
-                        xCoef = new double[10];
-                        yCoef = new double[10];
-                        xCoef[0] = 0;
-                        xCoef[1] = 1;
-                        xCoef[2] = 0;
-                        xCoef[3] = 0;
-                        xCoef[4] = 0;
-                        xCoef[5] = 0;
-                        xCoef[6] = 0;
-                        xCoef[7] = 0;
-                        xCoef[8] = 0;
-                        xCoef[9] = 0;
-                        yCoef[0] = 0;
-                        yCoef[1] = 0;
-                        yCoef[2] = 1;
-                        yCoef[3] = 0;
-                        yCoef[4] = 0;
-                        yCoef[5] = 0;
-                        yCoef[6] = 0;
-                        yCoef[7] = 0;
-                        yCoef[8] = 0;
-                        yCoef[9] = 0;
-                        break;
-                    }
-                    default:
-                        throw new OperatorException("Incorrect WARP degree");
+                if (warpPolynomialOrder < 1) {
+                    throw new OperatorException("Incorrect WARP degree");
                 }
+                // coefLen = 3, 6, 10, 15, ...
+                final int coefLen = (warpPolynomialOrder + 1) * (warpPolynomialOrder + 2) / 2;
+                xCoef = new double[coefLen];
+                yCoef = new double[coefLen];
+                for (int i = 0; i < coefLen; i++) {
+                    xCoef[i] = 0;
+                    yCoef[i] = 0;
+                }
+                xCoef[1] = 1;
+                yCoef[2] = 1;
+
+                jaiWarp = null;
+                
                 return;
             }
 


### PR DESCRIPTION
I ran into the exact same error that is described in the following forum posts:
* http://forum.step.esa.int/t/warp-error-during-coregistration-of-subsetted-sentinel-1a-data/825
* https://earth.esa.int/web/nest/user-community/forum/-/message_boards/message/1621452

I traced the problem to [this conditional block of code (WarpOp.java:1034)](https://github.com/senbox-org/s1tbx/blob/5de61cbb373a271417b18bad4b5c271007684887/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/WarpOp.java#L1034) that skips computing the warp polynomial when the GCP coordinates are identical in the master and slave images, i.e. the images are already perfectly aligned. The problem is that this code branch also leaves the `jaiWarp` field unset. `jaiWarp` is later used in the [`createWarpImage()`](https://github.com/senbox-org/s1tbx/blob/5de61cbb373a271417b18bad4b5c271007684887/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/WarpOp.java#L982) method where the exception occurs.

There are two obvious ways to fix this:
* correctly fill in the `jaiWarp` in that code block;
* simply skip the warping operation in `createWarpImage()` when `jaiWarp` is null.

My pull request uses the latter option. I think the best approach would be to do both, though, and indicate the lack of need for a warp via another variable.