### PR TITLE
use this convention to refer to raster dimensions:

### DIFF
--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/CrossCorrelationOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/CrossCorrelationOp.java
@@ -235,8 +235,8 @@ public class CrossCorrelationOp extends Operator {
             coarseWin = new CorrelationWindow(
                     Integer.parseInt(coarseRegistrationWindowWidth),
                     Integer.parseInt(coarseRegistrationWindowHeight),
-                    Integer.parseInt(rowInterpFactor),
                     Integer.parseInt(columnInterpFactor),
+                    Integer.parseInt(rowInterpFactor),
                     1);
 
             // parameters: Fine
@@ -253,8 +253,8 @@ public class CrossCorrelationOp extends Operator {
                     fineWin = new CorrelationWindow(
                             Integer.parseInt(fineRegistrationWindowWidth),
                             Integer.parseInt(fineRegistrationWindowHeight),
-                            Integer.parseInt(fineRegistrationWindowAccAzimuth),
                             Integer.parseInt(fineRegistrationWindowAccRange),
+                            Integer.parseInt(fineRegistrationWindowAccAzimuth),
                             Integer.parseInt(fineRegistrationOversampling));
                 }
             }


### PR DESCRIPTION
1. azimuth = line = row = raster height = Y
2. range = pixel = column = raster width = X