### PR TITLE
Add an option to use a standard grid across images

### DIFF
--- a/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/RangeDopplerGeocodingOp.java
+++ b/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/RangeDopplerGeocodingOp.java
@@ -68,7 +68,7 @@ import java.util.logging.Logger;
  * distortions is the ground elevation of the targets. This operator corrects the topographic distortion
  * in the raw image caused by this factor. The operator implements the Range-Doppler (RD) geocoding method.
  * <p/>
- * The method consis of the following major steps:
+ * The method consists of the following major steps:
  * (1) Get state vectors from the metadata;
  * (2) Compute satellite position and velocity for each azimuth time by interpolating the state vectors;
  * (3) Get corner latitudes and longitudes for the source image;
@@ -135,6 +135,15 @@ public class RangeDopplerGeocodingOp extends Operator {
 
     @Parameter(description = "The coordinate reference system in well known text format", defaultValue = "WGS84(DD)")
     private String mapProjection = "WGS84(DD)";
+
+    @Parameter(description = "Force the image grid to be aligned with a specific point", defaultValue = "false")
+    private boolean alignToStandardGrid = false;
+
+    @Parameter(description = "x-coordinate of the standard grid's origin point", defaultValue = "0")
+    private double standardGridOriginX = 0;
+
+    @Parameter(description = "y-coordinate of the standard grid's origin point", defaultValue = "0")
+    private double standardGridOriginY = 0;
 
     @Parameter(defaultValue = "true", label = "Mask out areas with no elevation", description = "Mask the sea with no data value (faster)")
     private boolean nodataValueAtSea = true;
@@ -527,7 +536,8 @@ public class RangeDopplerGeocodingOp extends Operator {
             delLon = pixelSpacingInDegree;
 
             final CRSGeoCodingHandler crsHandler = new CRSGeoCodingHandler(sourceProduct, mapProjection,
-                    pixelSpacingInDegree, pixelSpacingInMeter);
+                    pixelSpacingInDegree, pixelSpacingInMeter,
+                    alignToStandardGrid, standardGridOriginX, standardGridOriginY);
 
             targetCRS = crsHandler.getTargetCRS();
 

--- a/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/SARSimTerrainCorrectionOp.java
+++ b/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/SARSimTerrainCorrectionOp.java
@@ -137,6 +137,15 @@ public class SARSimTerrainCorrectionOp extends Operator {
     @Parameter(description = "The coordinate reference system in well known text format")
     private String mapProjection;
 
+    @Parameter(description = "Force the image grid to be aligned with a specific point", defaultValue = "false")
+    private boolean alignToStandardGrid = false;
+
+    @Parameter(description = "x-coordinate of the standard grid's origin point", defaultValue = "0")
+    private double standardGridOriginX = 0;
+
+    @Parameter(description = "y-coordinate of the standard grid's origin point", defaultValue = "0")
+    private double standardGridOriginY = 0;
+
     @Parameter(defaultValue = "false", label = "Save DEM as band")
     private boolean saveDEM = false;
 
@@ -532,7 +541,9 @@ public class SARSimTerrainCorrectionOp extends Operator {
         delLon = pixelSpacingInDegree;
 
         final CRSGeoCodingHandler crsHandler = new CRSGeoCodingHandler(sourceProduct, mapProjection,
-                                                                       pixelSpacingInDegree, pixelSpacingInMeter);
+                                                                       pixelSpacingInDegree, pixelSpacingInMeter,
+                                                                       alignToStandardGrid, standardGridOriginX,
+                                                                       standardGridOriginY);
 
         targetCRS = crsHandler.getTargetCRS();
 


### PR DESCRIPTION
I have been using SNAP heavily to preprocess stacks of full-scene GRDs and I have been doing this without any further coregistration, since the geolocation accuracy without has been good enough for me. The lack of coregistration creates a minor problem though: every image has a grid that is slight offset from all others. If they were aligned then creating a spatial subset from a stack would become a straightforward cropping operation. It's possible to resample all of them to a single grid using GDAL, for example, but I would prefer to solve this issue right inside SNAP, if possible.
Since [my question](http://forum.step.esa.int/t/how-can-i-snap-outputs-of-terrain-correction-to-a-given-grid/1750/2?u=valgur) on the STEP forum regarding this issue did not receive a response, I thought I might as well add this feature myself.

I added three parameters to `RangeDopplerGeocodingOp` and `SARSimTerrainCorrectionOp`: `alignToStandardGrid`, `standardGridOriginX` and `standardGridOriginY`. These specify whether to adjust the origin of the image grid to be aligned with a standard grid (defaults to false) and with what point (in the target CRS) should the grid align with (defaults to 0,0). I scanned the list of operations available in SNAP and found that only these two (or three, if you count `Ellipsoid-Correction-RD`) can make use of this feature (i.e., `Reproject` takes an absolute easting and northing value as an input and `Ellipsoid-Correction-GG` determines the pixel spacing automatically and does not allow it to be set).
This functionality is essentially the same as the [`-tap` parameter in `gdalwarp`](https://github.com/OSGeo/gdal/commit/624a0c00e53e5e23ae3a165a23be38be499930b2), by the way. Besides GDAL, there does not seem to be any good, established term for this shared grid as far as I can tell from, so I simply chose to call it a "standard grid".

I also did some testing to make sure everything works correctly. I ran a Read→Subset→Terrain-Correction→Write graph with two different, slightly offset subset polygons.
Here is the result
* without aligning the grids: [1](http://i.imgur.com/YyuPEQh.png), [2](http://i.imgur.com/vL3CyiB.png) and
* with the grids aligned: [1](http://i.imgur.com/4NjcChs.png), [2](http://i.imgur.com/0eirpD6.png).