### PR TITLE
s1tbx-io.4.x

### DIFF
--- a/jlinda/jlinda-core/pom.xml
+++ b/jlinda/jlinda-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jlinda</groupId>
         <artifactId>jlinda</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jlinda/jlinda-core/pom.xml
+++ b/jlinda/jlinda-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jlinda</groupId>
         <artifactId>jlinda</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jlinda/jlinda-core/pom.xml
+++ b/jlinda/jlinda-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jlinda</groupId>
         <artifactId>jlinda</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jlinda/jlinda-core/pom.xml
+++ b/jlinda/jlinda-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jlinda</groupId>
         <artifactId>jlinda</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jlinda/jlinda-core/pom.xml
+++ b/jlinda/jlinda-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jlinda</groupId>
         <artifactId>jlinda</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jlinda/jlinda-core/pom.xml
+++ b/jlinda/jlinda-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jlinda</groupId>
         <artifactId>jlinda</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jlinda/jlinda-core/pom.xml
+++ b/jlinda/jlinda-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jlinda</groupId>
         <artifactId>jlinda</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jlinda/jlinda-core/src/main/java/org/jlinda/core/coregistration/CPM.java
+++ b/jlinda/jlinda-core/src/main/java/org/jlinda/core/coregistration/CPM.java
@@ -275,10 +275,10 @@ public class CPM implements PolynomialModel {
 
         for (int i = 0; i < numObservations; i++) {
 
-            double height = heightMaster.getQuick(i);
+            Double height = heightMaster.getQuick(i);
 
             Point delta;
-            if (height == demNoDataValue) {
+            if (height.equals(demNoDataValue)) {
 
                 // skip this offset if corresponding height is no-data-value
                 delta = new Point(0, 0);

--- a/jlinda/jlinda-core/src/main/java/org/jlinda/core/geom/DemTile.java
+++ b/jlinda/jlinda-core/src/main/java/org/jlinda/core/geom/DemTile.java
@@ -29,7 +29,7 @@ public class DemTile {
     double longitudeDelta;
 
     // no data value
-    double noDataValue;
+    Double noDataValue;
 
     //// actual demTileData
     double[][] data;
@@ -66,7 +66,7 @@ public class DemTile {
     }
 
     public DemTile(double lat0, double lon0, long nLatPixels, long nLonPixels,
-                   double latitudeDelta, double longitudeDelta, long noDataValue) {
+                   double latitudeDelta, double longitudeDelta, double noDataValue) {
         this.lat0 = lat0;
         this.lon0 = lon0;
         this.nLatPixels = nLatPixels;
@@ -77,7 +77,7 @@ public class DemTile {
     }
 
     public DemTile(double lat0_ABS, double lon0_ABS, long nLatPixels_ABS, long nLonPixels_ABS,
-                   double delta, long noDataValue) {
+                   double delta, double noDataValue) {
 
         this.lat0_ABS = lat0_ABS;
         this.lon0_ABS = lon0_ABS;
@@ -117,10 +117,10 @@ public class DemTile {
         double min_dem_buffer = data[0][0];
         double max_dem_buffer = data[0][0];
 
-        if (max_dem_buffer == noDataValue) {
+        if (noDataValue.equals(max_dem_buffer)) {
             max_dem_buffer = 0;
         }
-        if (min_dem_buffer == noDataValue) {
+        if (noDataValue.equals(min_dem_buffer)) {
             min_dem_buffer = 0;
         }
 
@@ -128,7 +128,7 @@ public class DemTile {
             totalNumPoints = data.length * data[0].length;
             for (double[] aData : data) {
                 for (int j = 0; j < data[0].length; j++) {
-                    if (aData[j] != noDataValue) {
+                    if (!noDataValue.equals(aData[j])) {
                         numValid++;
                         meanValue += aData[j];           // divide by numValid later
                         if (aData[j] < min_dem_buffer)

--- a/jlinda/jlinda-nest-ui/pom.xml
+++ b/jlinda/jlinda-nest-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jlinda</artifactId>
         <groupId>org.jlinda</groupId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <name>jLinda NEST Support UI</name>

--- a/jlinda/jlinda-nest-ui/pom.xml
+++ b/jlinda/jlinda-nest-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jlinda</artifactId>
         <groupId>org.jlinda</groupId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <name>jLinda NEST Support UI</name>

--- a/jlinda/jlinda-nest-ui/pom.xml
+++ b/jlinda/jlinda-nest-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jlinda</artifactId>
         <groupId>org.jlinda</groupId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <name>jLinda NEST Support UI</name>

--- a/jlinda/jlinda-nest-ui/pom.xml
+++ b/jlinda/jlinda-nest-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jlinda</artifactId>
         <groupId>org.jlinda</groupId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <name>jLinda NEST Support UI</name>

--- a/jlinda/jlinda-nest-ui/pom.xml
+++ b/jlinda/jlinda-nest-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jlinda</artifactId>
         <groupId>org.jlinda</groupId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <name>jLinda NEST Support UI</name>

--- a/jlinda/jlinda-nest-ui/pom.xml
+++ b/jlinda/jlinda-nest-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jlinda</artifactId>
         <groupId>org.jlinda</groupId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <name>jLinda NEST Support UI</name>

--- a/jlinda/jlinda-nest-ui/pom.xml
+++ b/jlinda/jlinda-nest-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jlinda</artifactId>
         <groupId>org.jlinda</groupId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <name>jLinda NEST Support UI</name>

--- a/jlinda/jlinda-nest/pom.xml
+++ b/jlinda/jlinda-nest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jlinda</artifactId>
         <groupId>org.jlinda</groupId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <name>jLinda NEST Support</name>

--- a/jlinda/jlinda-nest/pom.xml
+++ b/jlinda/jlinda-nest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jlinda</artifactId>
         <groupId>org.jlinda</groupId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <name>jLinda NEST Support</name>

--- a/jlinda/jlinda-nest/pom.xml
+++ b/jlinda/jlinda-nest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jlinda</artifactId>
         <groupId>org.jlinda</groupId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <name>jLinda NEST Support</name>

--- a/jlinda/jlinda-nest/pom.xml
+++ b/jlinda/jlinda-nest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jlinda</artifactId>
         <groupId>org.jlinda</groupId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <name>jLinda NEST Support</name>

--- a/jlinda/jlinda-nest/pom.xml
+++ b/jlinda/jlinda-nest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jlinda</artifactId>
         <groupId>org.jlinda</groupId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <name>jLinda NEST Support</name>

--- a/jlinda/jlinda-nest/pom.xml
+++ b/jlinda/jlinda-nest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jlinda</artifactId>
         <groupId>org.jlinda</groupId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <name>jLinda NEST Support</name>

--- a/jlinda/jlinda-nest/pom.xml
+++ b/jlinda/jlinda-nest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jlinda</artifactId>
         <groupId>org.jlinda</groupId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <name>jLinda NEST Support</name>

--- a/jlinda/jlinda-nest/src/main/java/org/jlinda/nest/gpf/SimulateAmplitudeOp.java
+++ b/jlinda/jlinda-nest/src/main/java/org/jlinda/nest/gpf/SimulateAmplitudeOp.java
@@ -449,8 +449,8 @@ public final class SimulateAmplitudeOp extends Operator {
 
         // then for number of extra points
         for (int[] point : points) {
-            double height = dem.getSample(point[1], point[0]);
-            if (!Double.isNaN(height) && height != demNoDataValue) {
+            Double height = dem.getSample(point[1], point[0]);
+            if (!Double.isNaN(height) && !height.equals(demNoDataValue)) {
                 heights.add(height);
             }
         }

--- a/jlinda/jlinda-nest/src/main/java/org/jlinda/nest/gpf/SubtRefDemOp.java
+++ b/jlinda/jlinda-nest/src/main/java/org/jlinda/nest/gpf/SubtRefDemOp.java
@@ -595,8 +595,8 @@ public final class SubtRefDemOp extends Operator {
 
         // then for number of extra points
         for (int[] point : points) {
-            double height = dem.getSample(point[1], point[0]);
-            if (!Double.isNaN(height) && height != demNoDataValue) {
+            Double height = dem.getSample(point[1], point[0]);
+            if (!Double.isNaN(height) && !height.equals(demNoDataValue)) {
                 heights.add(height);
             }
         }

--- a/jlinda/jlinda-nest/src/main/java/org/jlinda/nest/gpf/coregistration/ResampleOp.java
+++ b/jlinda/jlinda-nest/src/main/java/org/jlinda/nest/gpf/coregistration/ResampleOp.java
@@ -506,7 +506,7 @@ public class ResampleOp extends Operator {
                     
                     double height = dem.getSample(demIndexPoint.x, demIndexPoint.y);
 
-                    if (Double.isNaN(height) || height == demNoDataValue) {
+                    if (Double.isNaN(height)) {
                         height = demNoDataValue;
                     }
 

--- a/jlinda/pom.xml
+++ b/jlinda/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
     
     <name>jLinda</name>

--- a/jlinda/pom.xml
+++ b/jlinda/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
     
     <name>jLinda</name>

--- a/jlinda/pom.xml
+++ b/jlinda/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
     
     <name>jLinda</name>

--- a/jlinda/pom.xml
+++ b/jlinda/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
     
     <name>jLinda</name>

--- a/jlinda/pom.xml
+++ b/jlinda/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
     
     <name>jLinda</name>

--- a/jlinda/pom.xml
+++ b/jlinda/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
     
     <name>jLinda</name>

--- a/jlinda/pom.xml
+++ b/jlinda/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
     
     <name>jLinda</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	
     <groupId>org.esa.s1tbx</groupId>
     <artifactId>s1tbx</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
     <name>Sentinel-1 Toolbox</name>
     <url>https://sentinel.esa.int/web/sentinel/toolboxes</url>
     <description>Tools for SAR Earth Observation</description>
@@ -32,9 +32,9 @@
             It is used to filter manifest.mf and set the manifest's "OpenIDE-Module-Specification-Version" header.
             This is necessary to make NetBeans modules updatable and independent from the Maven version (= s1tbx.version).
         -->
-		<s1tbx.version>4.0.3</s1tbx.version>
-        <rstb.version>7.2.3</rstb.version>
-        <jlinda.version>4.0.3</jlinda.version>
+		<s1tbx.version>4.0.4-SNAPSHOT</s1tbx.version>
+        <rstb.version>7.2.4-SNAPSHOT</rstb.version>
+        <jlinda.version>4.0.4-SNAPSHOT</jlinda.version>
         
 		<geotools.version>2.7.4</geotools.version>
 		<hdf.version>2.7.1</hdf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	
     <groupId>org.esa.s1tbx</groupId>
     <artifactId>s1tbx</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
+    <version>4.0.3</version>
     <name>Sentinel-1 Toolbox</name>
     <url>https://sentinel.esa.int/web/sentinel/toolboxes</url>
     <description>Tools for SAR Earth Observation</description>
@@ -32,9 +32,9 @@
             It is used to filter manifest.mf and set the manifest's "OpenIDE-Module-Specification-Version" header.
             This is necessary to make NetBeans modules updatable and independent from the Maven version (= s1tbx.version).
         -->
-		<s1tbx.version>4.0.3-SNAPSHOT</s1tbx.version>
-        <rstb.version>7.2.3-SNAPSHOT</rstb.version>
-        <jlinda.version>4.0.3-SNAPSHOT</jlinda.version>
+		<s1tbx.version>4.0.3</s1tbx.version>
+        <rstb.version>7.2.3</rstb.version>
+        <jlinda.version>4.0.3</jlinda.version>
         
 		<geotools.version>2.7.4</geotools.version>
 		<hdf.version>2.7.1</hdf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	
     <groupId>org.esa.s1tbx</groupId>
     <artifactId>s1tbx</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1-SNAPSHOT</version>
     <name>Sentinel-1 Toolbox</name>
     <url>https://sentinel.esa.int/web/sentinel/toolboxes</url>
     <description>Tools for SAR Earth Observation</description>
@@ -32,9 +32,9 @@
             It is used to filter manifest.mf and set the manifest's "OpenIDE-Module-Specification-Version" header.
             This is necessary to make NetBeans modules updatable and independent from the Maven version (= s1tbx.version).
         -->
-		<s1tbx.version>4.0.0</s1tbx.version>
-        <rstb.version>7.2.0</rstb.version>
-        <jlinda.version>4.0.0</jlinda.version>
+		<s1tbx.version>4.0.1-SNAPSHOT</s1tbx.version>
+        <rstb.version>7.2.1-SNAPSHOT</rstb.version>
+        <jlinda.version>4.0.1-SNAPSHOT</jlinda.version>
         
 		<geotools.version>2.7.4</geotools.version>
 		<hdf.version>2.7.1</hdf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	
     <groupId>org.esa.s1tbx</groupId>
     <artifactId>s1tbx</artifactId>
-    <version>4.0.4-SNAPSHOT</version>
+    <version>4.0.4</version>
     <name>Sentinel-1 Toolbox</name>
     <url>https://sentinel.esa.int/web/sentinel/toolboxes</url>
     <description>Tools for SAR Earth Observation</description>
@@ -25,16 +25,16 @@
         <test.jvm.arguments>-Xmx${test.jvm.maxheapsize}</test.jvm.arguments>
         <surefire.jvm.args>${test.jvm.arguments} -enableassertions</surefire.jvm.args>
 
-        <snap.version>4.1.0-SNAPSHOT</snap.version>
+        <snap.version>4.0.2</snap.version>
         <!--
             s1tbx.version is the Maven module version.
             s1tbx.nbmSpecVersion is the NetBeans module specification version.
             It is used to filter manifest.mf and set the manifest's "OpenIDE-Module-Specification-Version" header.
             This is necessary to make NetBeans modules updatable and independent from the Maven version (= s1tbx.version).
         -->
-		<s1tbx.version>4.0.4-SNAPSHOT</s1tbx.version>
-        <rstb.version>7.2.4-SNAPSHOT</rstb.version>
-        <jlinda.version>4.0.4-SNAPSHOT</jlinda.version>
+		<s1tbx.version>4.0.4</s1tbx.version>
+        <rstb.version>7.2.4</rstb.version>
+        <jlinda.version>4.0.4</jlinda.version>
         
 		<geotools.version>2.7.4</geotools.version>
 		<hdf.version>2.7.1</hdf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <test.jvm.arguments>-Xmx${test.jvm.maxheapsize}</test.jvm.arguments>
         <surefire.jvm.args>${test.jvm.arguments} -enableassertions</surefire.jvm.args>
 
-        <snap.version>4.0.2</snap.version>
+        <snap.version>4.1.0-SNAPSHOT</snap.version>
         <!--
             s1tbx.version is the Maven module version.
             s1tbx.nbmSpecVersion is the NetBeans module specification version.

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <test.jvm.arguments>-Xmx${test.jvm.maxheapsize}</test.jvm.arguments>
         <surefire.jvm.args>${test.jvm.arguments} -enableassertions</surefire.jvm.args>
 
-        <snap.version>4.1.0-SNAPSHOT</snap.version>
+        <snap.version>4.1.0</snap.version>
         <!--
             s1tbx.version is the Maven module version.
             s1tbx.nbmSpecVersion is the NetBeans module specification version.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	
     <groupId>org.esa.s1tbx</groupId>
     <artifactId>s1tbx</artifactId>
-    <version>4.0.2</version>
+    <version>4.0.3-SNAPSHOT</version>
     <name>Sentinel-1 Toolbox</name>
     <url>https://sentinel.esa.int/web/sentinel/toolboxes</url>
     <description>Tools for SAR Earth Observation</description>
@@ -32,9 +32,9 @@
             It is used to filter manifest.mf and set the manifest's "OpenIDE-Module-Specification-Version" header.
             This is necessary to make NetBeans modules updatable and independent from the Maven version (= s1tbx.version).
         -->
-		<s1tbx.version>4.0.2</s1tbx.version>
-        <rstb.version>7.2.2</rstb.version>
-        <jlinda.version>4.0.2</jlinda.version>
+		<s1tbx.version>4.0.3-SNAPSHOT</s1tbx.version>
+        <rstb.version>7.2.3-SNAPSHOT</rstb.version>
+        <jlinda.version>4.0.3-SNAPSHOT</jlinda.version>
         
 		<geotools.version>2.7.4</geotools.version>
 		<hdf.version>2.7.1</hdf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	
     <groupId>org.esa.s1tbx</groupId>
     <artifactId>s1tbx</artifactId>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.0.2</version>
     <name>Sentinel-1 Toolbox</name>
     <url>https://sentinel.esa.int/web/sentinel/toolboxes</url>
     <description>Tools for SAR Earth Observation</description>
@@ -25,16 +25,16 @@
         <test.jvm.arguments>-Xmx${test.jvm.maxheapsize}</test.jvm.arguments>
         <surefire.jvm.args>${test.jvm.arguments} -enableassertions</surefire.jvm.args>
 
-        <snap.version>4.0.1</snap.version>
+        <snap.version>4.0.2</snap.version>
         <!--
             s1tbx.version is the Maven module version.
             s1tbx.nbmSpecVersion is the NetBeans module specification version.
             It is used to filter manifest.mf and set the manifest's "OpenIDE-Module-Specification-Version" header.
             This is necessary to make NetBeans modules updatable and independent from the Maven version (= s1tbx.version).
         -->
-		<s1tbx.version>4.0.1-SNAPSHOT</s1tbx.version>
-        <rstb.version>7.2.1-SNAPSHOT</rstb.version>
-        <jlinda.version>4.0.1-SNAPSHOT</jlinda.version>
+		<s1tbx.version>4.0.2</s1tbx.version>
+        <rstb.version>7.2.2</rstb.version>
+        <jlinda.version>4.0.2</jlinda.version>
         
 		<geotools.version>2.7.4</geotools.version>
 		<hdf.version>2.7.1</hdf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	
     <groupId>org.esa.s1tbx</groupId>
     <artifactId>s1tbx</artifactId>
-    <version>4.0.4</version>
+    <version>4.0.5-SNAPSHOT</version>
     <name>Sentinel-1 Toolbox</name>
     <url>https://sentinel.esa.int/web/sentinel/toolboxes</url>
     <description>Tools for SAR Earth Observation</description>
@@ -25,16 +25,16 @@
         <test.jvm.arguments>-Xmx${test.jvm.maxheapsize}</test.jvm.arguments>
         <surefire.jvm.args>${test.jvm.arguments} -enableassertions</surefire.jvm.args>
 
-        <snap.version>4.0.2</snap.version>
+        <snap.version>4.1.0-SNAPSHOT</snap.version>
         <!--
             s1tbx.version is the Maven module version.
             s1tbx.nbmSpecVersion is the NetBeans module specification version.
             It is used to filter manifest.mf and set the manifest's "OpenIDE-Module-Specification-Version" header.
             This is necessary to make NetBeans modules updatable and independent from the Maven version (= s1tbx.version).
         -->
-		<s1tbx.version>4.0.4</s1tbx.version>
-        <rstb.version>7.2.4</rstb.version>
-        <jlinda.version>4.0.4</jlinda.version>
+		<s1tbx.version>4.0.5-SNAPSHOT</s1tbx.version>
+        <rstb.version>7.2.5-SNAPSHOT</rstb.version>
+        <jlinda.version>4.0.5-SNAPSHOT</jlinda.version>
         
 		<geotools.version>2.7.4</geotools.version>
 		<hdf.version>2.7.1</hdf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <test.jvm.arguments>-Xmx${test.jvm.maxheapsize}</test.jvm.arguments>
         <surefire.jvm.args>${test.jvm.arguments} -enableassertions</surefire.jvm.args>
 
-        <snap.version>4.0.0</snap.version>
+        <snap.version>4.0.1</snap.version>
         <!--
             s1tbx.version is the Maven module version.
             s1tbx.nbmSpecVersion is the NetBeans module specification version.

--- a/rstb/pom.xml
+++ b/rstb/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <name>RADARSAT-2 Toolbox</name>
     <groupId>org.csa.rstb</groupId>
     <artifactId>rstb</artifactId>
-    <version>7.2.3-SNAPSHOT</version>
+    <version>7.2.3</version>
 
     <packaging>pom</packaging>
 

--- a/rstb/pom.xml
+++ b/rstb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>7.2.1-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <name>RADARSAT-2 Toolbox</name>

--- a/rstb/pom.xml
+++ b/rstb/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <name>RADARSAT-2 Toolbox</name>
     <groupId>org.csa.rstb</groupId>
     <artifactId>rstb</artifactId>
-    <version>7.2.1-SNAPSHOT</version>
+    <version>7.2.2</version>
 
     <packaging>pom</packaging>
 

--- a/rstb/pom.xml
+++ b/rstb/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <name>RADARSAT-2 Toolbox</name>
     <groupId>org.csa.rstb</groupId>
     <artifactId>rstb</artifactId>
-    <version>7.2.2</version>
+    <version>7.2.3-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/rstb/pom.xml
+++ b/rstb/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <name>RADARSAT-2 Toolbox</name>
     <groupId>org.csa.rstb</groupId>
     <artifactId>rstb</artifactId>
-    <version>7.2.4-SNAPSHOT</version>
+    <version>7.2.4</version>
 
     <packaging>pom</packaging>
 

--- a/rstb/pom.xml
+++ b/rstb/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <name>RADARSAT-2 Toolbox</name>
     <groupId>org.csa.rstb</groupId>
     <artifactId>rstb</artifactId>
-    <version>7.2.3</version>
+    <version>7.2.4-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/rstb/pom.xml
+++ b/rstb/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>7.2.1-SNAPSHOT</version>
     </parent>
 
     <name>RADARSAT-2 Toolbox</name>
     <groupId>org.csa.rstb</groupId>
     <artifactId>rstb</artifactId>
-    <version>7.2.0</version>
+    <version>7.2.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/rstb/pom.xml
+++ b/rstb/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <name>RADARSAT-2 Toolbox</name>
     <groupId>org.csa.rstb</groupId>
     <artifactId>rstb</artifactId>
-    <version>7.2.4</version>
+    <version>7.2.5-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/rstb/rstb-kit/pom.xml
+++ b/rstb/rstb-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.3-SNAPSHOT</version>
+        <version>7.2.3</version>
     </parent>
 
     <artifactId>rstb-kit</artifactId>

--- a/rstb/rstb-kit/pom.xml
+++ b/rstb/rstb-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.1-SNAPSHOT</version>
+        <version>7.2.2</version>
     </parent>
 
     <artifactId>rstb-kit</artifactId>

--- a/rstb/rstb-kit/pom.xml
+++ b/rstb/rstb-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.0</version>
+        <version>7.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>rstb-kit</artifactId>

--- a/rstb/rstb-kit/pom.xml
+++ b/rstb/rstb-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.4-SNAPSHOT</version>
+        <version>7.2.4</version>
     </parent>
 
     <artifactId>rstb-kit</artifactId>

--- a/rstb/rstb-kit/pom.xml
+++ b/rstb/rstb-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.2</version>
+        <version>7.2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>rstb-kit</artifactId>

--- a/rstb/rstb-kit/pom.xml
+++ b/rstb/rstb-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.4</version>
+        <version>7.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>rstb-kit</artifactId>

--- a/rstb/rstb-kit/pom.xml
+++ b/rstb/rstb-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.3</version>
+        <version>7.2.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>rstb-kit</artifactId>

--- a/rstb/rstb-op-classification-ui/pom.xml
+++ b/rstb/rstb-op-classification-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.4-SNAPSHOT</version>
+        <version>7.2.4</version>
     </parent>
 
     <name>RSTB Classification Tools UI</name>

--- a/rstb/rstb-op-classification-ui/pom.xml
+++ b/rstb/rstb-op-classification-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.1-SNAPSHOT</version>
+        <version>7.2.2</version>
     </parent>
 
     <name>RSTB Classification Tools UI</name>

--- a/rstb/rstb-op-classification-ui/pom.xml
+++ b/rstb/rstb-op-classification-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.0</version>
+        <version>7.2.1-SNAPSHOT</version>
     </parent>
 
     <name>RSTB Classification Tools UI</name>

--- a/rstb/rstb-op-classification-ui/pom.xml
+++ b/rstb/rstb-op-classification-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.3-SNAPSHOT</version>
+        <version>7.2.3</version>
     </parent>
 
     <name>RSTB Classification Tools UI</name>

--- a/rstb/rstb-op-classification-ui/pom.xml
+++ b/rstb/rstb-op-classification-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.3</version>
+        <version>7.2.4-SNAPSHOT</version>
     </parent>
 
     <name>RSTB Classification Tools UI</name>

--- a/rstb/rstb-op-classification-ui/pom.xml
+++ b/rstb/rstb-op-classification-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.2</version>
+        <version>7.2.3-SNAPSHOT</version>
     </parent>
 
     <name>RSTB Classification Tools UI</name>

--- a/rstb/rstb-op-classification-ui/pom.xml
+++ b/rstb/rstb-op-classification-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.4</version>
+        <version>7.2.5-SNAPSHOT</version>
     </parent>
 
     <name>RSTB Classification Tools UI</name>

--- a/rstb/rstb-op-classification/pom.xml
+++ b/rstb/rstb-op-classification/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.0</version>
+        <version>7.2.1-SNAPSHOT</version>
     </parent>
 
     <name>RSTB Classification Tools</name>

--- a/rstb/rstb-op-classification/pom.xml
+++ b/rstb/rstb-op-classification/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.1-SNAPSHOT</version>
+        <version>7.2.2</version>
     </parent>
 
     <name>RSTB Classification Tools</name>

--- a/rstb/rstb-op-classification/pom.xml
+++ b/rstb/rstb-op-classification/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.4-SNAPSHOT</version>
+        <version>7.2.4</version>
     </parent>
 
     <name>RSTB Classification Tools</name>

--- a/rstb/rstb-op-classification/pom.xml
+++ b/rstb/rstb-op-classification/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.3</version>
+        <version>7.2.4-SNAPSHOT</version>
     </parent>
 
     <name>RSTB Classification Tools</name>

--- a/rstb/rstb-op-classification/pom.xml
+++ b/rstb/rstb-op-classification/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.2</version>
+        <version>7.2.3-SNAPSHOT</version>
     </parent>
 
     <name>RSTB Classification Tools</name>

--- a/rstb/rstb-op-classification/pom.xml
+++ b/rstb/rstb-op-classification/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.3-SNAPSHOT</version>
+        <version>7.2.3</version>
     </parent>
 
     <name>RSTB Classification Tools</name>

--- a/rstb/rstb-op-classification/pom.xml
+++ b/rstb/rstb-op-classification/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.4</version>
+        <version>7.2.5-SNAPSHOT</version>
     </parent>
 
     <name>RSTB Classification Tools</name>

--- a/rstb/rstb-op-classification/src/main/java/org/csa/rstb/classification/gpf/classifiers/HAlphaWishart.java
+++ b/rstb/rstb-op-classification/src/main/java/org/csa/rstb/classification/gpf/classifiers/HAlphaWishart.java
@@ -112,7 +112,7 @@ public class HAlphaWishart extends PolClassifierBase implements PolClassifier {
         final TileIndex trgIndex = new TileIndex(targetTile);
         final TileIndex srcIndex = new TileIndex(sourceTiles[0]);
 
-        final double noDataValue = srcBandList.srcBands[0].getNoDataValue();
+        final Double noDataValue = srcBandList.srcBands[0].getNoDataValue();
 
         final double[][] Tr = new double[3][3];
         final double[][] Ti = new double[3][3];
@@ -122,7 +122,7 @@ public class HAlphaWishart extends PolClassifierBase implements PolClassifier {
             srcIndex.calculateStride(y);
             for (int x = x0; x < maxX; ++x) {
                 final int index = trgIndex.getIndex(x);
-                if (dataBuffers[0].getElemDoubleAt(srcIndex.getIndex(x)) == noDataValue) {
+                if (noDataValue.equals(dataBuffers[0].getElemDoubleAt(srcIndex.getIndex(x)))) {
                     targetData.setElemIntAt(index, NODATACLASS);
                 } else {
                     PolOpUtils.getMeanCoherencyMatrix(x, y, halfWindowSizeX, halfWindowSizeY, srcWidth, srcHeight,
@@ -184,7 +184,7 @@ public class HAlphaWishart extends PolClassifierBase implements PolClassifier {
         final double[][][] centerRe = new double[9][3][3];
         final double[][][] centerIm = new double[9][3][3];
         final int[] counter = new int[9];
-        final double noDataValue = srcBandList.srcBands[0].getNoDataValue();
+        final Double noDataValue = srcBandList.srcBands[0].getNoDataValue();
 
         final ThreadManager threadManager = new ThreadManager();
 
@@ -220,7 +220,7 @@ public class HAlphaWishart extends PolClassifierBase implements PolClassifier {
                         for (int y = y0; y < yMax; ++y) {
                             srcIndex.calculateStride(y);
                             for (int x = x0; x < xMax; ++x) {
-                                if (dataBuffers[0].getElemDoubleAt(srcIndex.getIndex(x)) == noDataValue)
+                                if (noDataValue.equals(dataBuffers[0].getElemDoubleAt(srcIndex.getIndex(x))))
                                     continue;
 
                                 PolOpUtils.getMeanCoherencyMatrix(x, y, halfWindowSizeX, halfWindowSizeY, srcWidth, srcHeight,
@@ -283,7 +283,7 @@ public class HAlphaWishart extends PolClassifierBase implements PolClassifier {
         final double[][][] centerRe = new double[9][3][3];
         final double[][][] centerIm = new double[9][3][3];
         boolean endIteration = false;
-        final double noDataValue = srcBandList.srcBands[0].getNoDataValue();
+        final Double noDataValue = srcBandList.srcBands[0].getNoDataValue();
 
         final StatusProgressMonitor status = new StatusProgressMonitor(StatusProgressMonitor.TYPE.SUBTASK);
         status.beginTask("Computing Final Cluster Centres... ", tileRectangles.length * maxIterations);
@@ -329,7 +329,7 @@ public class HAlphaWishart extends PolClassifierBase implements PolClassifier {
                             for (int y = y0; y < yMax; ++y) {
                                 srcIndex.calculateStride(y);
                                 for (int x = x0; x < xMax; ++x) {
-                                    if (dataBuffers[0].getElemDoubleAt(srcIndex.getIndex(x)) == noDataValue)
+                                    if (noDataValue.equals(dataBuffers[0].getElemDoubleAt(srcIndex.getIndex(x))))
                                         continue;
 
                                     PolOpUtils.getMeanCoherencyMatrix(x, y, halfWindowSizeX, halfWindowSizeY, srcWidth, srcHeight,

--- a/rstb/rstb-op-classification/src/main/java/org/csa/rstb/classification/gpf/classifiers/HAlphaWishartC2.java
+++ b/rstb/rstb-op-classification/src/main/java/org/csa/rstb/classification/gpf/classifiers/HAlphaWishartC2.java
@@ -79,11 +79,11 @@ public class HAlphaWishartC2 extends PolClassifierBase implements PolClassifier 
         return 9;
     }
 
-    private boolean noData(final double noDataValue, final ProductData[] dataBuffers, final int index) {
+    private boolean noData(final Double noDataValue, final ProductData[] dataBuffers, final int index) {
         // It is assumed that all the data buffers have the same no data value.
         int numNoDataBuf = 0;
         for (ProductData buf : dataBuffers) {
-            if (buf.getElemDoubleAt(index) == noDataValue) {
+            if (noDataValue.equals(buf.getElemDoubleAt(index))) {
                 numNoDataBuf++;
             }
         }

--- a/rstb/rstb-op-polarimetric-tools-ui/pom.xml
+++ b/rstb/rstb-op-polarimetric-tools-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.0</version>
+        <version>7.2.1-SNAPSHOT</version>
     </parent>
 
     <name>RSTB Polarimetric SAR Tools UI</name>

--- a/rstb/rstb-op-polarimetric-tools-ui/pom.xml
+++ b/rstb/rstb-op-polarimetric-tools-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.4</version>
+        <version>7.2.5-SNAPSHOT</version>
     </parent>
 
     <name>RSTB Polarimetric SAR Tools UI</name>

--- a/rstb/rstb-op-polarimetric-tools-ui/pom.xml
+++ b/rstb/rstb-op-polarimetric-tools-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.4-SNAPSHOT</version>
+        <version>7.2.4</version>
     </parent>
 
     <name>RSTB Polarimetric SAR Tools UI</name>

--- a/rstb/rstb-op-polarimetric-tools-ui/pom.xml
+++ b/rstb/rstb-op-polarimetric-tools-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.3</version>
+        <version>7.2.4-SNAPSHOT</version>
     </parent>
 
     <name>RSTB Polarimetric SAR Tools UI</name>

--- a/rstb/rstb-op-polarimetric-tools-ui/pom.xml
+++ b/rstb/rstb-op-polarimetric-tools-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.3-SNAPSHOT</version>
+        <version>7.2.3</version>
     </parent>
 
     <name>RSTB Polarimetric SAR Tools UI</name>

--- a/rstb/rstb-op-polarimetric-tools-ui/pom.xml
+++ b/rstb/rstb-op-polarimetric-tools-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.2</version>
+        <version>7.2.3-SNAPSHOT</version>
     </parent>
 
     <name>RSTB Polarimetric SAR Tools UI</name>

--- a/rstb/rstb-op-polarimetric-tools-ui/pom.xml
+++ b/rstb/rstb-op-polarimetric-tools-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.1-SNAPSHOT</version>
+        <version>7.2.2</version>
     </parent>
 
     <name>RSTB Polarimetric SAR Tools UI</name>

--- a/rstb/rstb-op-polarimetric-tools/pom.xml
+++ b/rstb/rstb-op-polarimetric-tools/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.0</version>
+        <version>7.2.1-SNAPSHOT</version>
     </parent>
 
     <name>RSTB Polarimetric SAR Tools</name>

--- a/rstb/rstb-op-polarimetric-tools/pom.xml
+++ b/rstb/rstb-op-polarimetric-tools/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.3</version>
+        <version>7.2.4-SNAPSHOT</version>
     </parent>
 
     <name>RSTB Polarimetric SAR Tools</name>

--- a/rstb/rstb-op-polarimetric-tools/pom.xml
+++ b/rstb/rstb-op-polarimetric-tools/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.1-SNAPSHOT</version>
+        <version>7.2.2</version>
     </parent>
 
     <name>RSTB Polarimetric SAR Tools</name>

--- a/rstb/rstb-op-polarimetric-tools/pom.xml
+++ b/rstb/rstb-op-polarimetric-tools/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.4</version>
+        <version>7.2.5-SNAPSHOT</version>
     </parent>
 
     <name>RSTB Polarimetric SAR Tools</name>

--- a/rstb/rstb-op-polarimetric-tools/pom.xml
+++ b/rstb/rstb-op-polarimetric-tools/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.3-SNAPSHOT</version>
+        <version>7.2.3</version>
     </parent>
 
     <name>RSTB Polarimetric SAR Tools</name>

--- a/rstb/rstb-op-polarimetric-tools/pom.xml
+++ b/rstb/rstb-op-polarimetric-tools/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.4-SNAPSHOT</version>
+        <version>7.2.4</version>
     </parent>
 
     <name>RSTB Polarimetric SAR Tools</name>

--- a/rstb/rstb-op-polarimetric-tools/pom.xml
+++ b/rstb/rstb-op-polarimetric-tools/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.csa.rstb</groupId>
         <artifactId>rstb</artifactId>
-        <version>7.2.2</version>
+        <version>7.2.3-SNAPSHOT</version>
     </parent>
 
     <name>RSTB Polarimetric SAR Tools</name>

--- a/rstb/rstb-op-polarimetric-tools/src/main/java/org/csa/rstb/polarimetric/gpf/decompositions/FreemanDurden.java
+++ b/rstb/rstb-op-polarimetric-tools/src/main/java/org/csa/rstb/polarimetric/gpf/decompositions/FreemanDurden.java
@@ -160,7 +160,7 @@ public class FreemanDurden extends DecompositionBase implements Decomposition {
         c33 = Cr[2][2] - fv * 3.0 / 8.0;
         final double a1 = c11 * c33;
 
-        if (Math.abs(c11) <= Constants.EPS || Math.abs(c33) <= Constants.EPS) {
+        if (c11 <= Constants.EPS || c33 <= Constants.EPS) {
             fs = 0.0;
             fd = 0.0;
             alphaRe = 0.0;

--- a/s1tbx-benchmark/pom.xml
+++ b/s1tbx-benchmark/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Benchmark Tests</name>

--- a/s1tbx-benchmark/pom.xml
+++ b/s1tbx-benchmark/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <name>S1TBX Benchmark Tests</name>

--- a/s1tbx-benchmark/pom.xml
+++ b/s1tbx-benchmark/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Benchmark Tests</name>

--- a/s1tbx-benchmark/pom.xml
+++ b/s1tbx-benchmark/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <name>S1TBX Benchmark Tests</name>

--- a/s1tbx-benchmark/pom.xml
+++ b/s1tbx-benchmark/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Benchmark Tests</name>

--- a/s1tbx-benchmark/pom.xml
+++ b/s1tbx-benchmark/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Benchmark Tests</name>

--- a/s1tbx-benchmark/pom.xml
+++ b/s1tbx-benchmark/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <name>S1TBX Benchmark Tests</name>

--- a/s1tbx-commons/pom.xml
+++ b/s1tbx-commons/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Commons</name>

--- a/s1tbx-commons/pom.xml
+++ b/s1tbx-commons/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <name>S1TBX Commons</name>

--- a/s1tbx-commons/pom.xml
+++ b/s1tbx-commons/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <name>S1TBX Commons</name>

--- a/s1tbx-commons/pom.xml
+++ b/s1tbx-commons/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Commons</name>

--- a/s1tbx-commons/pom.xml
+++ b/s1tbx-commons/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Commons</name>

--- a/s1tbx-commons/pom.xml
+++ b/s1tbx-commons/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <name>S1TBX Commons</name>

--- a/s1tbx-commons/pom.xml
+++ b/s1tbx-commons/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Commons</name>

--- a/s1tbx-config/pom.xml
+++ b/s1tbx-config/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/s1tbx-config/pom.xml
+++ b/s1tbx-config/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/s1tbx-config/pom.xml
+++ b/s1tbx-config/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/s1tbx-config/pom.xml
+++ b/s1tbx-config/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/s1tbx-config/pom.xml
+++ b/s1tbx-config/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/s1tbx-config/pom.xml
+++ b/s1tbx-config/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/s1tbx-config/pom.xml
+++ b/s1tbx-config/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/s1tbx-io/pom.xml
+++ b/s1tbx-io/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-io</artifactId>

--- a/s1tbx-io/pom.xml
+++ b/s1tbx-io/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-io</artifactId>

--- a/s1tbx-io/pom.xml
+++ b/s1tbx-io/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <artifactId>s1tbx-io</artifactId>

--- a/s1tbx-io/pom.xml
+++ b/s1tbx-io/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-io</artifactId>

--- a/s1tbx-io/pom.xml
+++ b/s1tbx-io/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <artifactId>s1tbx-io</artifactId>

--- a/s1tbx-io/pom.xml
+++ b/s1tbx-io/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-io</artifactId>

--- a/s1tbx-io/pom.xml
+++ b/s1tbx-io/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <artifactId>s1tbx-io</artifactId>

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/binary/ArrayCopy.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/binary/ArrayCopy.java
@@ -168,4 +168,41 @@ public class ArrayCopy {
 
         return Float.intBitsToFloat(((s << 31) | (e << 23) | f));
     }
+
+    public static float toFloat(final short s) {
+
+        // FAB16 FLOATING-POINT ARITHMETIC FORMAT
+        //
+        // Based on c code...
+        //
+        // #define FLT16_ZERO     0
+        //
+        // typedef unsigned short Real2;
+        // typedef float Real4;
+        //
+        // Real4 f32r_(Real2 *a)
+        // {
+        //    register unsigned int i32a;
+        //    if ( !(i32a = (unsigned int)*a) )
+        //    return (Real4)FLT16_ZERO;
+        //    register unsigned int e_o = ((i32a & 0x00007800) + 0x0001D000) << 13;
+        //    unsigned int f32r = ((i32a & 0x00008000) << 16) | e_o | (i32a & 0x000007FF) << 13;
+        //    return *(Real4*)&f32r;
+        // }
+
+        if (s == 0) return 0;
+
+        final int i32a = s & 0xffff; // unsigned short
+
+        final int e_o = ((i32a & 0x00007800) + 0x0001D000) << 13;
+
+        final int a1 = ((i32a & 0x00008000) << 16);
+        final int a2 = (i32a & 0x000007FF) << 13;
+
+        final int f32r = a1 | e_o | a2;
+
+        final float f = Float.intBitsToFloat(f32r);
+
+        return f;
+    }
 }

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/ceos/alos2/Alos2ProductReader.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/ceos/alos2/Alos2ProductReader.java
@@ -71,11 +71,13 @@ public class Alos2ProductReader extends CEOSProductReader {
     @Override
     protected void addQuicklooks(final Product product, final VirtualDir productDir) throws IOException {
         final String[] files = productDir.list("");
-        for(String file : files) {
-            String name = file.toLowerCase();
-            if(name.startsWith("brs") && name.endsWith(".jpg")) {
-                addQuicklook(product, Quicklook.DEFAULT_QUICKLOOK_NAME, productDir.getFile(file));
-                return;
+        if(files != null) {
+            for (String file : files) {
+                String name = file.toLowerCase();
+                if (name.startsWith("brs") && name.endsWith(".jpg")) {
+                    addQuicklook(product, Quicklook.DEFAULT_QUICKLOOK_NAME, productDir.getFile(file));
+                    return;
+                }
             }
         }
     }

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/gamma/GammaConstants.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/gamma/GammaConstants.java
@@ -5,8 +5,12 @@ public class GammaConstants {
     public static final String HEADER_KEY_NAME = "title";
     public static final String HEADER_KEY_SAMPLES = "range_samples";
     public static final String HEADER_KEY_SAMPLES1 = "range_samp_1";
+    public static final String HEADER_KEY_WIDTH = "width";
+    public static final String HEADER_KEY_NCOLUMNS = "ncolumns";
     public static final String HEADER_KEY_LINES = "azimuth_lines";
     public static final String HEADER_KEY_LINES1 = "az_samp_1";
+    public static final String HEADER_KEY_HEIGHT = "height";
+    public static final String HEADER_KEY_NLINES = "nlines";
     public static final String HEADER_KEY_BANDS = "bands";
     public static final String HEADER_KEY_HEADER_OFFSET = "line_header_size";
     public static final String HEADER_KEY_DATA_TYPE = "image_format";

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/gamma/GammaProductReaderPlugIn.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/gamma/GammaProductReaderPlugIn.java
@@ -31,7 +31,7 @@ public class GammaProductReaderPlugIn implements ProductReaderPlugIn {
 
     public final static String DESCRIPTION = "Gamma File Format";
     public final static String[] FORMATS = new String[]{"Gamma"};
-    public final static String EXT = ".par";
+    public final static String[] EXTs = new String[] {".par",".diff_par"};
 
     /**
      * Checks whether the given object is an acceptable input for this product reader and if so, the method checks if it
@@ -44,8 +44,10 @@ public class GammaProductReaderPlugIn implements ProductReaderPlugIn {
         final File file = ReaderUtils.getFileFromInput(input);
         if (file != null) {
             final String filename = file.getName().toLowerCase();
-            if (filename.endsWith(EXT)) {
-                return DecodeQualification.INTENDED;
+            for(String ext : EXTs) {
+                if (filename.endsWith(ext)) {
+                    return DecodeQualification.INTENDED;
+                }
             }
         }
 
@@ -96,7 +98,7 @@ public class GammaProductReaderPlugIn implements ProductReaderPlugIn {
      * @return the default file extensions for this product I/O plug-in, never <code>null</code>
      */
     public String[] getDefaultFileExtensions() {
-        return new String[]{EXT};
+        return EXTs;
     }
 
     /**
@@ -118,7 +120,7 @@ public class GammaProductReaderPlugIn implements ProductReaderPlugIn {
             super();
             setFormatName(FORMATS[0]);
             setDescription(DESCRIPTION);
-            setExtensions(new String[]{EXT});
+            setExtensions(EXTs);
         }
 
         /**
@@ -131,9 +133,14 @@ public class GammaProductReaderPlugIn implements ProductReaderPlugIn {
          */
         public boolean accept(final File file) {
             if (super.accept(file)) {
-                final String name = file.getName().toLowerCase();
-                if (file.isDirectory() || name.endsWith(EXT)) {
+                if (file.isDirectory()) {
                     return true;
+                }
+                final String name = file.getName().toLowerCase();
+                for(String ext : EXTs) {
+                    if (name.endsWith(ext)) {
+                        return true;
+                    }
                 }
             }
             return false;

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/gamma/GammaProductWriter.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/gamma/GammaProductWriter.java
@@ -30,6 +30,7 @@ import org.esa.snap.core.datamodel.VirtualBand;
 import org.esa.snap.core.gpf.Tile;
 import org.esa.snap.core.gpf.internal.TileImpl;
 import org.esa.snap.core.util.Guardian;
+import org.esa.snap.core.util.SystemUtils;
 import org.esa.snap.engine_utilities.datamodel.Unit;
 
 import javax.imageio.stream.ImageOutputStream;
@@ -80,6 +81,8 @@ public class GammaProductWriter extends AbstractProductWriter {
 
         srcProduct = getSourceProduct();
         srcProduct.setProductWriter(this);
+
+        //System.out.println("outputFile = " + outputFile.getName());
 
         headerWriter = new HeaderWriter(this, srcProduct, outputFile);
         headerWriter.writeParFile();
@@ -273,7 +276,17 @@ public class GammaProductWriter extends AbstractProductWriter {
     }
 
     private File getImageFile(final Band band) {
-        return new File(outputDir, createImageFilename(band));
+        //return new File(outputDir, createImageFilename(band));
+        String filename = band.getName();
+        if (!filename.contains(".")) {
+            //System.out.println("baseFileName = " + headerWriter.getBaseFileName());
+            filename = filename + GammaConstants.SLC_EXTENSION;
+        }
+        if (filename.startsWith("i_") || filename.startsWith("q_")) {
+            filename = filename.substring(2);
+        }
+        //System.out.println("getImageFile: band = " + band.getName() + " outputDir = " + outputDir.getName() + " filename = " + filename);
+        return new File(outputDir, filename);
     }
 
     /**

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/gamma/GammaProductWriter.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/gamma/GammaProductWriter.java
@@ -167,9 +167,9 @@ public class GammaProductWriter extends AbstractProductWriter {
     private Band getComplexSrcBand(final Band iBand) {
         String name = iBand.getName();
         if (name.startsWith("i_")) {
-            name.replace("i_", "q_");
+            name = name.replace("i_", "q_");
         } else if (name.startsWith("q_")) {
-            name.replace("q_", "i_");
+            name = name.replace("q_", "i_");
         }
         return srcProduct.getBand(name);
     }

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/gamma/GammaProductWriterPlugIn.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/gamma/GammaProductWriterPlugIn.java
@@ -59,7 +59,7 @@ public class GammaProductWriterPlugIn implements ProductWriterPlugIn {
      * @return the default file extensions for this product I/O plug-in, never <code>null</code>
      */
     public String[] getDefaultFileExtensions() {
-        return new String[]{GammaProductReaderPlugIn.EXT};
+        return GammaProductReaderPlugIn.EXTs;
     }
 
     /**

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/gamma/Header.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/gamma/Header.java
@@ -37,7 +37,13 @@ public class Header {
     public int getNumSamples() {
         int val = headerParser.getInt(GammaConstants.HEADER_KEY_SAMPLES, 0);
         if(val == 0) {
-            val = headerParser.getInt(GammaConstants.HEADER_KEY_SAMPLES1);
+            val = headerParser.getInt(GammaConstants.HEADER_KEY_SAMPLES1, 0);
+        }
+        if(val == 0) {
+            val = headerParser.getInt(GammaConstants.HEADER_KEY_WIDTH, 0);
+        }
+        if(val == 0) {
+            val = headerParser.getInt(GammaConstants.HEADER_KEY_NCOLUMNS);
         }
         return val;
     }
@@ -45,7 +51,13 @@ public class Header {
     public int getNumLines() {
         int val = headerParser.getInt(GammaConstants.HEADER_KEY_LINES, 0);
         if(val == 0) {
-            val = headerParser.getInt(GammaConstants.HEADER_KEY_LINES1);
+            val = headerParser.getInt(GammaConstants.HEADER_KEY_LINES1, 0);
+        }
+        if(val == 0) {
+            val = headerParser.getInt(GammaConstants.HEADER_KEY_HEIGHT, 0);
+        }
+        if(val == 0) {
+            val = headerParser.getInt(GammaConstants.HEADER_KEY_NLINES);
         }
         return val;
     }
@@ -87,11 +99,11 @@ public class Header {
     }
 
     public int getRangeLooks() {
-        return headerParser.getInt(GammaConstants.HEADER_KEY_RANGE_LOOKS);
+        return headerParser.getInt(GammaConstants.HEADER_KEY_RANGE_LOOKS, 1);
     }
 
     public int getAzimuthLooks() {
-        return headerParser.getInt(GammaConstants.HEADER_KEY_AZIMUTH_LOOKS);
+        return headerParser.getInt(GammaConstants.HEADER_KEY_AZIMUTH_LOOKS, 1);
     }
 
     public double getLineTimeInterval() {

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/gamma/HeaderWriter.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/gamma/HeaderWriter.java
@@ -31,7 +31,7 @@ import java.io.PrintStream;
 /**
  * Writer par header
  */
-public class HeaderWriter {
+class HeaderWriter {
 
     private final File outputFile;
     private final Product srcProduct;
@@ -43,7 +43,7 @@ public class HeaderWriter {
 
     private final static String sep = ":\t";
 
-    public HeaderWriter(final GammaProductWriter writer, final Product srcProduct, final File userOutputFile) {
+    HeaderWriter(final GammaProductWriter writer, final Product srcProduct, final File userOutputFile) {
         this.writer = writer;
         this.srcProduct = srcProduct;
         this.isComplex = false;
@@ -62,11 +62,13 @@ public class HeaderWriter {
         this.baseFileName = FileUtils.getFilenameWithoutExtension(this.outputFile);
     }
 
-    public String getBaseFileName() {
+    String getBaseFileName() {
         return baseFileName;
     }
 
-    public void writeParFile() throws IOException {
+    void writeParFile() throws IOException {
+        final String oldEOL = System.getProperty("line.separator");
+        System.setProperty("line.separator", "\n");
         final FileOutputStream out = new FileOutputStream(outputFile);
         try(PrintStream p = new PrintStream(out)) {
 
@@ -84,10 +86,12 @@ public class HeaderWriter {
             p.flush();
         } catch (Exception e) {
             throw new IOException("GammaWriter unable to write par file " + e.getMessage());
+        } finally {
+            System.setProperty("line.separator", oldEOL);
         }
     }
 
-    public int getHighestElemSize() {
+    int getHighestElemSize() {
         int highestElemSize = 0;
         for(Band band : srcProduct.getBands()) {
             if(writer.shouldWrite(band)) {

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/gamma/HeaderWriter.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/gamma/HeaderWriter.java
@@ -118,7 +118,7 @@ class HeaderWriter {
         String name = FileUtils.getFilenameWithoutExtension(file);
         String ext = FileUtils.getExtension(name);
         String newExt = GammaConstants.PAR_EXTENSION;
-        if (ext == null || !ext.endsWith("slc")) {
+        if (ext == null) {
             if (isComplex) {
                 if (isCoregistered) {
                     newExt = ".rslc" + newExt;

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/QCScraper.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/QCScraper.java
@@ -17,6 +17,7 @@ package org.esa.s1tbx.io.orbits;
 
 
 import org.esa.snap.core.util.StringUtils;
+import org.esa.snap.core.util.SystemUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -72,7 +73,7 @@ public class QCScraper {
         return fileList.toArray(new String[fileList.size()]);
     }
 
-    private List<String> getFileURLs(String path, final Set<String> currentList) {
+    private static List<String> getFileURLs(String path, final Set<String> currentList) {
         final List<String> fileList = new ArrayList<>();
         try {
             final Document doc = Jsoup.connect(path).timeout(10*1000).validateTLSCertificates(false).get();
@@ -93,7 +94,7 @@ public class QCScraper {
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            SystemUtils.LOG.warning("Unable to connect to "+path+ ": "+e.getMessage());
         }
         return fileList;
     }

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/delft/DelftOrbitFile.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/delft/DelftOrbitFile.java
@@ -13,8 +13,9 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see http://www.gnu.org/licenses/
  */
-package org.esa.s1tbx.io.orbits;
+package org.esa.s1tbx.io.orbits.delft;
 
+import org.esa.s1tbx.io.orbits.BaseOrbitFile;
 import org.esa.snap.core.datamodel.MetadataElement;
 import org.esa.snap.core.datamodel.Product;
 import org.esa.snap.engine_utilities.datamodel.AbstractMetadata;

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/delft/OrbitalDataRecordReader.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/delft/OrbitalDataRecordReader.java
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see http://www.gnu.org/licenses/
  */
-package org.esa.s1tbx.io.orbits;
+package org.esa.s1tbx.io.orbits.delft;
 
 import org.esa.snap.core.datamodel.ProductData;
 import org.esa.snap.core.gpf.OperatorException;

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/doris/DorisOrbitFile.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/doris/DorisOrbitFile.java
@@ -13,9 +13,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see http://www.gnu.org/licenses/
  */
-package org.esa.s1tbx.io.orbits;
+package org.esa.s1tbx.io.orbits.doris;
 
 import com.bc.ceres.core.NullProgressMonitor;
+import org.esa.s1tbx.io.orbits.BaseOrbitFile;
 import org.esa.snap.core.datamodel.MetadataElement;
 import org.esa.snap.core.datamodel.Product;
 import org.esa.snap.core.dataop.downloadable.FtpDownloader;

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/prare/PrareOrbitFile.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/prare/PrareOrbitFile.java
@@ -13,9 +13,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see http://www.gnu.org/licenses/
  */
-package org.esa.s1tbx.io.orbits;
+package org.esa.s1tbx.io.orbits.prare;
 
 import com.bc.ceres.core.NullProgressMonitor;
+import org.esa.s1tbx.io.orbits.BaseOrbitFile;
 import org.esa.snap.core.datamodel.MetadataElement;
 import org.esa.snap.core.datamodel.Product;
 import org.esa.snap.core.dataop.downloadable.FtpDownloader;

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/prare/PrareOrbitReader.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/prare/PrareOrbitReader.java
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see http://www.gnu.org/licenses/
  */
-package org.esa.s1tbx.io.orbits;
+package org.esa.s1tbx.io.orbits.prare;
 
 import org.esa.snap.core.datamodel.ProductData;
 import org.esa.snap.core.gpf.OperatorException;

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/sentinel1/QCScraper.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/sentinel1/QCScraper.java
@@ -31,10 +31,10 @@ import java.util.Set;
 /**
  * Download orbit files directly from QC website
  */
-public class QCScraper {
+class QCScraper {
 
-    public static final String POEORB = "aux_poeorb";
-    public static final String RESORB = "aux_resorb";
+    private static final String POEORB = "aux_poeorb";
+    private static final String RESORB = "aux_resorb";
 
     private static final String qcUrl = "https://qc.sentinel1.eo.esa.int/";
     private static final String pageVar = "/?page=";
@@ -44,16 +44,20 @@ public class QCScraper {
 
     private final String orbitType;
 
-    public QCScraper(final String orbitType) {
-        this.orbitType = orbitType;
+    QCScraper(final String orbitType) {
+        if (orbitType.contains("Restituted")) {
+            this.orbitType = RESORB;
+        } else {
+            this.orbitType = POEORB;
+        }
         System.setProperty("jsse.enableSNIExtension", "false");
     }
 
-    public String getRemoteURL() {
+    String getRemoteURL() {
         return qcUrl + orbitType + '/';
     }
 
-    public String[] getFileURLs(final String mission, final int year, final int month) {
+    String[] getFileURLs(final String mission, final int year, final int month) {
         final Set<String> fileList = new HashSet<>();
         String monthStr = StringUtils.padNum(month, 2, '0');
 

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/sentinel1/QCScraper.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/sentinel1/QCScraper.java
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see http://www.gnu.org/licenses/
  */
-package org.esa.s1tbx.io.orbits;
+package org.esa.s1tbx.io.orbits.sentinel1;
 
 
 import org.esa.snap.core.util.StringUtils;

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/sentinel1/SentinelPODOrbitFile.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/sentinel1/SentinelPODOrbitFile.java
@@ -13,9 +13,11 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see http://www.gnu.org/licenses/
  */
-package org.esa.s1tbx.io.orbits;
+package org.esa.s1tbx.io.orbits.sentinel1;
 
 import Jama.Matrix;
+import org.esa.s1tbx.io.orbits.BaseOrbitFile;
+import org.esa.s1tbx.io.orbits.OrbitFile;
 import org.esa.snap.core.datamodel.MetadataElement;
 import org.esa.snap.core.datamodel.ProductData;
 import org.esa.snap.core.gpf.OperatorException;

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/sentinel1/StepAuxdataScraper.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/sentinel1/StepAuxdataScraper.java
@@ -17,6 +17,7 @@ package org.esa.s1tbx.io.orbits.sentinel1;
 
 
 import org.esa.snap.core.util.StringUtils;
+import org.esa.snap.core.util.SystemUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -30,23 +31,30 @@ import java.util.Set;
 /**
  * Download orbit files directly from QC website
  */
-public class StepAuxdataScraper {
+class StepAuxdataScraper {
 
     private static final String stepS1OrbitsUrl = "http://step.esa.int/auxdata/orbits/Sentinel-1/";
+
+    private static final String POEORB = "POEORB";
+    private static final String RESORB = "RESORB";
 
     private final String orbitType;
     private String remotePath;
 
-    public StepAuxdataScraper(final String orbitType) {
-        this.orbitType = orbitType;
+    StepAuxdataScraper(final String orbitType) {
+        if(orbitType.contains("Restituted")) {
+            this.orbitType = RESORB;
+        } else {
+            this.orbitType = POEORB;
+        }
         System.setProperty("jsse.enableSNIExtension", "false");
     }
 
-    public String getRemoteURL() {
+    String getRemoteURL() {
         return remotePath;
     }
 
-    public String[] getFileURLs(final String mission, final int year, final int month) {
+    String[] getFileURLs(final String mission, final int year, final int month) {
         final String monthStr = StringUtils.padNum(month, 2, '0');
 
         remotePath = stepS1OrbitsUrl + orbitType + '/' + mission + '/' + year + '/' + monthStr + '/';
@@ -77,7 +85,7 @@ public class StepAuxdataScraper {
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            SystemUtils.LOG.warning("Unable to connect to "+path+ ": "+e.getMessage());
         }
         return fileList;
     }

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/sentinel1/StepAuxdataScraper.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/orbits/sentinel1/StepAuxdataScraper.java
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see http://www.gnu.org/licenses/
  */
-package org.esa.s1tbx.io.orbits;
+package org.esa.s1tbx.io.orbits.sentinel1;
 
 
 import org.esa.snap.core.util.StringUtils;

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/sentinel1/Sentinel1Level1Directory.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/sentinel1/Sentinel1Level1Directory.java
@@ -28,6 +28,7 @@ import org.esa.snap.core.datamodel.ProductData;
 import org.esa.snap.core.datamodel.TiePointGeoCoding;
 import org.esa.snap.core.datamodel.TiePointGrid;
 import org.esa.snap.core.dataop.downloadable.XMLSupport;
+import org.esa.snap.core.util.SystemUtils;
 import org.esa.snap.core.util.io.FileUtils;
 import org.esa.snap.core.util.math.MathUtils;
 import org.esa.snap.engine_utilities.datamodel.AbstractMetadata;
@@ -75,19 +76,23 @@ public class Sentinel1Level1Directory extends XMLProductDirectory implements Sen
     protected void addImageFile(final String imgPath, final MetadataElement newRoot) throws IOException {
         final String name = getBandFileNameFromImage(imgPath);
         if ((name.endsWith("tiff"))) {
-            final Dimension bandDimensions = getBandDimensions(newRoot, imgBandMetadataMap.get(name));
-            final InputStream inStream = getInputStream(imgPath);
-            final ImageInputStream imgStream = ImageIOFile.createImageInputStream(inStream, bandDimensions);
+            try {
+                final Dimension bandDimensions = getBandDimensions(newRoot, imgBandMetadataMap.get(name));
+                final InputStream inStream = getInputStream(imgPath);
+                final ImageInputStream imgStream = ImageIOFile.createImageInputStream(inStream, bandDimensions);
 
-            final ImageIOFile img;
-            if (isSLC()) {
-                img = new ImageIOFile(name, imgStream, ImageIOFile.getTiffIIOReader(imgStream),
-                                      1, 1, ProductData.TYPE_INT32, productInputFile);
-            } else {
-                img = new ImageIOFile(name, imgStream, ImageIOFile.getTiffIIOReader(imgStream),
-                                      1, 1, ProductData.TYPE_INT32, productInputFile);
+                final ImageIOFile img;
+                if (isSLC()) {
+                    img = new ImageIOFile(name, imgStream, ImageIOFile.getTiffIIOReader(imgStream),
+                            1, 1, ProductData.TYPE_INT32, productInputFile);
+                } else {
+                    img = new ImageIOFile(name, imgStream, ImageIOFile.getTiffIIOReader(imgStream),
+                            1, 1, ProductData.TYPE_INT32, productInputFile);
+                }
+                bandImageFileMap.put(img.getName(), img);
+            } catch (Exception e) {
+                SystemUtils.LOG.severe(imgPath +" not found");
             }
-            bandImageFileMap.put(img.getName(), img);
         }
     }
 

--- a/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/TestStepAuxdataScraper.java
+++ b/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/TestStepAuxdataScraper.java
@@ -21,39 +21,39 @@ import org.junit.Test;
 import static junit.framework.TestCase.assertEquals;
 
 /**
- * Test Sentinel-1 QC Scrapping of orbit files
+ * find files on step
  */
-public class TestQCScraper {
+public class TestStepAuxdataScraper {
 
     @Test
     public void testDownloadPreciseOrbitFileS1A() {
-        final QCScraper qc = new QCScraper(QCScraper.POEORB);
+        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.POEORB);
 
-        String[] orbitFiles = qc.getFileURLs("S1A", 2016, 2);
+        String[] orbitFiles = step.getFileURLs("S1A", 2016, 2);
         assertEquals(29, orbitFiles.length);
     }
 
     @Test
     public void testDownloadPreciseOrbitFileS1B() {
-        final QCScraper qc = new QCScraper(QCScraper.POEORB);
+        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.POEORB);
 
-        String[] orbitFiles = qc.getFileURLs("S1B", 2016, 7);
+        String[] orbitFiles = step.getFileURLs("S1B", 2016, 7);
         assertEquals(31, orbitFiles.length);
     }
 
     @Test
     public void testDownloadRestituteOrbitFileS1A() {
-        final QCScraper qc = new QCScraper(QCScraper.RESORB);
+        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.RESORB);
 
-        String[] orbitFiles = qc.getFileURLs("S1A", 2016, 3);
-        assertEquals(636, orbitFiles.length);
+        String[] orbitFiles = step.getFileURLs("S1A", 2016, 2);
+        assertEquals(591, orbitFiles.length);
     }
 
     @Test
     public void testDownloadRestituteOrbitFileS1B() {
-        final QCScraper qc = new QCScraper(QCScraper.RESORB);
+        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.RESORB);
 
-        String[] orbitFiles = qc.getFileURLs("S1B", 2016, 7);
+        String[] orbitFiles = step.getFileURLs("S1B", 2016, 7);
         assertEquals(592, orbitFiles.length);
     }
 }

--- a/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/delft/TestOrbitalDataRecordReader.java
+++ b/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/delft/TestOrbitalDataRecordReader.java
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see http://www.gnu.org/licenses/
  */
-package org.esa.s1tbx.io.orbits;
+package org.esa.s1tbx.io.orbits.delft;
 
 import org.esa.snap.core.util.ResourceInstaller;
 import org.esa.snap.engine_utilities.util.TestUtils;

--- a/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestQCScraper.java
+++ b/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestQCScraper.java
@@ -15,6 +15,7 @@
  */
 package org.esa.s1tbx.io.orbits.sentinel1;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertEquals;
@@ -22,6 +23,7 @@ import static junit.framework.TestCase.assertEquals;
 /**
  * Test Sentinel-1 QC Scrapping of orbit files
  */
+@Ignore("Takes too long")
 public class TestQCScraper {
 
     @Test

--- a/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestQCScraper.java
+++ b/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestQCScraper.java
@@ -13,47 +13,46 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see http://www.gnu.org/licenses/
  */
-package org.esa.s1tbx.io.orbits;
+package org.esa.s1tbx.io.orbits.sentinel1;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertEquals;
 
 /**
- * find files on step
+ * Test Sentinel-1 QC Scrapping of orbit files
  */
-public class TestStepAuxdataScraper {
+public class TestQCScraper {
 
     @Test
     public void testDownloadPreciseOrbitFileS1A() {
-        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.POEORB);
+        final QCScraper qc = new QCScraper(QCScraper.POEORB);
 
-        String[] orbitFiles = step.getFileURLs("S1A", 2016, 2);
+        String[] orbitFiles = qc.getFileURLs("S1A", 2016, 2);
         assertEquals(29, orbitFiles.length);
     }
 
     @Test
     public void testDownloadPreciseOrbitFileS1B() {
-        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.POEORB);
+        final QCScraper qc = new QCScraper(QCScraper.POEORB);
 
-        String[] orbitFiles = step.getFileURLs("S1B", 2016, 7);
+        String[] orbitFiles = qc.getFileURLs("S1B", 2016, 7);
         assertEquals(31, orbitFiles.length);
     }
 
     @Test
     public void testDownloadRestituteOrbitFileS1A() {
-        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.RESORB);
+        final QCScraper qc = new QCScraper(QCScraper.RESORB);
 
-        String[] orbitFiles = step.getFileURLs("S1A", 2016, 2);
-        assertEquals(591, orbitFiles.length);
+        String[] orbitFiles = qc.getFileURLs("S1A", 2016, 3);
+        assertEquals(636, orbitFiles.length);
     }
 
     @Test
     public void testDownloadRestituteOrbitFileS1B() {
-        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.RESORB);
+        final QCScraper qc = new QCScraper(QCScraper.RESORB);
 
-        String[] orbitFiles = step.getFileURLs("S1B", 2016, 7);
+        String[] orbitFiles = qc.getFileURLs("S1B", 2016, 7);
         assertEquals(592, orbitFiles.length);
     }
 }

--- a/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestQCScraper.java
+++ b/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestQCScraper.java
@@ -26,7 +26,7 @@ public class TestQCScraper {
 
     @Test
     public void testDownloadPreciseOrbitFileS1A() {
-        final QCScraper qc = new QCScraper(QCScraper.POEORB);
+        final QCScraper qc = new QCScraper(SentinelPODOrbitFile.PRECISE);
 
         String[] orbitFiles = qc.getFileURLs("S1A", 2016, 2);
         assertEquals(29, orbitFiles.length);
@@ -34,7 +34,7 @@ public class TestQCScraper {
 
     @Test
     public void testDownloadPreciseOrbitFileS1B() {
-        final QCScraper qc = new QCScraper(QCScraper.POEORB);
+        final QCScraper qc = new QCScraper(SentinelPODOrbitFile.PRECISE);
 
         String[] orbitFiles = qc.getFileURLs("S1B", 2016, 7);
         assertEquals(31, orbitFiles.length);
@@ -42,7 +42,7 @@ public class TestQCScraper {
 
     @Test
     public void testDownloadRestituteOrbitFileS1A() {
-        final QCScraper qc = new QCScraper(QCScraper.RESORB);
+        final QCScraper qc = new QCScraper(SentinelPODOrbitFile.RESTITUTED);
 
         String[] orbitFiles = qc.getFileURLs("S1A", 2016, 3);
         assertEquals(636, orbitFiles.length);
@@ -50,7 +50,7 @@ public class TestQCScraper {
 
     @Test
     public void testDownloadRestituteOrbitFileS1B() {
-        final QCScraper qc = new QCScraper(QCScraper.RESORB);
+        final QCScraper qc = new QCScraper(SentinelPODOrbitFile.RESTITUTED);
 
         String[] orbitFiles = qc.getFileURLs("S1B", 2016, 7);
         assertEquals(592, orbitFiles.length);

--- a/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestSentinelOrbitRetrieval.java
+++ b/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestSentinelOrbitRetrieval.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2016 by Array Systems Computing Inc. http://www.array.ca
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see http://www.gnu.org/licenses/
+ */
+package org.esa.s1tbx.io.orbits.sentinel1;
+
+import org.esa.snap.core.util.SystemUtils;
+import org.esa.snap.core.util.io.FileUtils;
+import org.esa.snap.engine_utilities.datamodel.DownloadableContentImpl;
+import org.esa.snap.engine_utilities.util.ZipUtils;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+
+import static junit.framework.TestCase.assertEquals;
+
+/**
+ * Test Sentinel-1 QC Scrapping of orbit files
+ */
+public class TestSentinelOrbitRetrieval {
+    private static final int STARTYEARS1A = 2014;
+    private static final int STARTYEARS1B = 2015;
+    private static final int ENDYEAR = 2017;
+    private static final String S1A = "S1A";
+    private static final String S1B = "S1B";
+
+    private static final boolean ZIP = false;
+
+    @Test
+    @Ignore
+    public void testDownloadAllPreciseOrbitFiles() throws IOException {
+
+        retrieveMission(S1A, SentinelPODOrbitFile.PRECISE, STARTYEARS1A, ENDYEAR);
+
+        retrieveMission(S1B, SentinelPODOrbitFile.PRECISE, STARTYEARS1B, ENDYEAR);
+    }
+
+    @Test
+    @Ignore
+    public void testDownloadAllRestitudedOrbitFiles() throws IOException {
+
+        retrieveMission(S1A, SentinelPODOrbitFile.RESTITUTED, STARTYEARS1A, ENDYEAR);
+
+        retrieveMission(S1B, SentinelPODOrbitFile.RESTITUTED, STARTYEARS1B, ENDYEAR);
+    }
+
+    private void retrieveMission(final String missionPrefix, final String orbitType,
+                                final int startYear, final int endYear) throws IOException {
+        SentinelPODOrbitFile.disableSSLCertificateCheck();
+
+        for(int year=startYear; year < endYear; ++year) {
+            for(int month=1; month <= 12; ++month) {
+                retrieveFolder(missionPrefix, orbitType, year, month);
+            }
+        }
+
+        SentinelPODOrbitFile.enableSSLCertificateCheck();
+    }
+
+    private void retrieveFolder(final String missionPrefix, final String orbitType, final int year, final int month)
+            throws IOException {
+        final File destFolder = SentinelPODOrbitFile.getDestFolder(missionPrefix, orbitType, year, month);
+
+        final QCScraper qc = new QCScraper(orbitType);
+        final URL remotePath = new URL(qc.getRemoteURL());
+        final String[] orbitFiles = qc.getFileURLs(missionPrefix, year, month);
+
+        if(orbitFiles.length == 0) {
+            return;
+        }
+
+        SystemUtils.LOG.info("Retrieving " + orbitFiles.length +" files " + year + ' ' + month + " to " + destFolder.getAbsolutePath());
+
+        int cnt = 0;
+        for (String file : orbitFiles) {
+            final File newFile = new File(destFolder, file);
+            final File localZipFile = FileUtils.exchangeExtension(newFile, ".EOF.zip");
+            if (!newFile.exists() && !localZipFile.exists()) {
+                download(remotePath, newFile);
+                ++cnt;
+            }
+        }
+        if (cnt > 0) {
+            SystemUtils.LOG.info(cnt + " new files retrieved");
+        }
+
+        final File[] localFiles = destFolder.listFiles();
+        assertEquals(orbitFiles.length, localFiles.length);
+
+        final StepAuxdataScraper step = new StepAuxdataScraper(orbitType);
+        final String[] stepOrbitFiles = step.getFileURLs(missionPrefix, year, month);
+        if(orbitFiles.length != stepOrbitFiles.length) {
+            SystemUtils.LOG.severe("Step "+ missionPrefix +' '+ year +' '+ month + " incomplete");
+            SystemUtils.LOG.severe("Step "+ stepOrbitFiles.length + " vs QC " + orbitFiles.length);
+            //assertEquals(orbitFiles.length, stepOrbitFiles.length);
+        }
+    }
+
+    private void download(final URL remotePath, final File file) throws IOException {
+
+        DownloadableContentImpl.getRemoteHttpFile(remotePath, file);
+        if (ZIP && file.exists()) {
+            final File localZipFile = FileUtils.exchangeExtension(file, ".EOF.zip");
+            ZipUtils.zipFile(file, localZipFile);
+            file.delete();
+        }
+    }
+}

--- a/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestSentinelPODOrbitFile.java
+++ b/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestSentinelPODOrbitFile.java
@@ -147,20 +147,28 @@ public class TestSentinelPODOrbitFile {
 
 
         String str = podOrbitFile.getMissionFromHeader();
-        TestUtils.log.info("Mission from Header = " + str);
-        assert(str.startsWith("Sentinel-1"));
+        if(str != null) {
+            TestUtils.log.info("Mission from Header = " + str);
+            assert (str.startsWith("Sentinel-1"));
+        }
 
         str = podOrbitFile.getFileTypeFromHeader();
-        TestUtils.log.info("File_Type from Header = " + str);
-        assert(str.equals("AUX_POEORB"));
+        if(str != null) {
+            TestUtils.log.info("File_Type from Header = " + str);
+            assert (str.equals("AUX_POEORB"));
+        }
 
         str = podOrbitFile.getValidityStartFromHeader();
-        TestUtils.log.info("Validity_Start from Header = " + str);
-        assert(str.equals("UTC=2015-08-27T22:59:43"));
+        if(str != null) {
+            TestUtils.log.info("Validity_Start from Header = " + str);
+            assert (str.equals("UTC=2015-08-27T22:59:43"));
+        }
 
         str = podOrbitFile.getValidityStopFromHeader();
-        TestUtils.log.info("Validity_Stop from Header = " + str);
-        assert(str.equals("UTC=2015-08-29T00:59:43"));
+        if(str != null) {
+            TestUtils.log.info("Validity_Stop from Header = " + str);
+            assert (str.equals("UTC=2015-08-29T00:59:43"));
+        }
 
         final String missionID = SentinelPODOrbitFile.getMissionIDFromFilename("S1A_OPER_AUX_POEORB_OPOD_20140526T151322_V20140509T225944_20140511T005944.EOF");
         TestUtils.log.info("mission ID from filename = " + missionID);

--- a/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestSentinelPODOrbitFile.java
+++ b/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestSentinelPODOrbitFile.java
@@ -1,6 +1,7 @@
-package org.esa.s1tbx.io.orbits;
+package org.esa.s1tbx.io.orbits.sentinel1;
 
 import org.esa.s1tbx.commons.TestData;
+import org.esa.s1tbx.io.orbits.sentinel1.SentinelPODOrbitFile;
 import org.esa.snap.core.dataio.ProductIO;
 import org.esa.snap.core.datamodel.MetadataElement;
 import org.esa.snap.core.datamodel.Product;

--- a/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestSentinelPODOrbitFile.java
+++ b/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestSentinelPODOrbitFile.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 by Array Systems Computing Inc. http://www.array.ca
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see http://www.gnu.org/licenses/
+ */
 package org.esa.s1tbx.io.orbits.sentinel1;
 
 import org.esa.s1tbx.commons.TestData;

--- a/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestStepAuxdataScraper.java
+++ b/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestStepAuxdataScraper.java
@@ -13,47 +13,48 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see http://www.gnu.org/licenses/
  */
-package org.esa.s1tbx.io.orbits;
+package org.esa.s1tbx.io.orbits.sentinel1;
 
-import org.junit.Ignore;
+import org.esa.s1tbx.io.orbits.sentinel1.SentinelPODOrbitFile;
+import org.esa.s1tbx.io.orbits.sentinel1.StepAuxdataScraper;
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertEquals;
 
 /**
- * Test Sentinel-1 QC Scrapping of orbit files
+ * find files on step
  */
-public class TestQCScraper {
+public class TestStepAuxdataScraper {
 
     @Test
     public void testDownloadPreciseOrbitFileS1A() {
-        final QCScraper qc = new QCScraper(QCScraper.POEORB);
+        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.POEORB);
 
-        String[] orbitFiles = qc.getFileURLs("S1A", 2016, 2);
+        String[] orbitFiles = step.getFileURLs("S1A", 2016, 2);
         assertEquals(29, orbitFiles.length);
     }
 
     @Test
     public void testDownloadPreciseOrbitFileS1B() {
-        final QCScraper qc = new QCScraper(QCScraper.POEORB);
+        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.POEORB);
 
-        String[] orbitFiles = qc.getFileURLs("S1B", 2016, 7);
+        String[] orbitFiles = step.getFileURLs("S1B", 2016, 7);
         assertEquals(31, orbitFiles.length);
     }
 
     @Test
     public void testDownloadRestituteOrbitFileS1A() {
-        final QCScraper qc = new QCScraper(QCScraper.RESORB);
+        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.RESORB);
 
-        String[] orbitFiles = qc.getFileURLs("S1A", 2016, 3);
-        assertEquals(636, orbitFiles.length);
+        String[] orbitFiles = step.getFileURLs("S1A", 2016, 2);
+        assertEquals(591, orbitFiles.length);
     }
 
     @Test
     public void testDownloadRestituteOrbitFileS1B() {
-        final QCScraper qc = new QCScraper(QCScraper.RESORB);
+        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.RESORB);
 
-        String[] orbitFiles = qc.getFileURLs("S1B", 2016, 7);
+        String[] orbitFiles = step.getFileURLs("S1B", 2016, 7);
         assertEquals(592, orbitFiles.length);
     }
 }

--- a/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestStepAuxdataScraper.java
+++ b/s1tbx-io/src/test/java/org/esa/s1tbx/io/orbits/sentinel1/TestStepAuxdataScraper.java
@@ -15,8 +15,6 @@
  */
 package org.esa.s1tbx.io.orbits.sentinel1;
 
-import org.esa.s1tbx.io.orbits.sentinel1.SentinelPODOrbitFile;
-import org.esa.s1tbx.io.orbits.sentinel1.StepAuxdataScraper;
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertEquals;
@@ -28,7 +26,7 @@ public class TestStepAuxdataScraper {
 
     @Test
     public void testDownloadPreciseOrbitFileS1A() {
-        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.POEORB);
+        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.PRECISE);
 
         String[] orbitFiles = step.getFileURLs("S1A", 2016, 2);
         assertEquals(29, orbitFiles.length);
@@ -36,7 +34,7 @@ public class TestStepAuxdataScraper {
 
     @Test
     public void testDownloadPreciseOrbitFileS1B() {
-        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.POEORB);
+        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.PRECISE);
 
         String[] orbitFiles = step.getFileURLs("S1B", 2016, 7);
         assertEquals(31, orbitFiles.length);
@@ -44,7 +42,7 @@ public class TestStepAuxdataScraper {
 
     @Test
     public void testDownloadRestituteOrbitFileS1A() {
-        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.RESORB);
+        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.RESTITUTED);
 
         String[] orbitFiles = step.getFileURLs("S1A", 2016, 2);
         assertEquals(591, orbitFiles.length);
@@ -52,7 +50,7 @@ public class TestStepAuxdataScraper {
 
     @Test
     public void testDownloadRestituteOrbitFileS1B() {
-        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.RESORB);
+        final StepAuxdataScraper step = new StepAuxdataScraper(SentinelPODOrbitFile.RESTITUTED);
 
         String[] orbitFiles = step.getFileURLs("S1B", 2016, 7);
         assertEquals(592, orbitFiles.length);

--- a/s1tbx-kit/pom.xml
+++ b/s1tbx-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s1tbx</artifactId>
         <groupId>org.esa.s1tbx</groupId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-kit</artifactId>

--- a/s1tbx-kit/pom.xml
+++ b/s1tbx-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s1tbx</artifactId>
         <groupId>org.esa.s1tbx</groupId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-kit</artifactId>

--- a/s1tbx-kit/pom.xml
+++ b/s1tbx-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s1tbx</artifactId>
         <groupId>org.esa.s1tbx</groupId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <artifactId>s1tbx-kit</artifactId>

--- a/s1tbx-kit/pom.xml
+++ b/s1tbx-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s1tbx</artifactId>
         <groupId>org.esa.s1tbx</groupId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <artifactId>s1tbx-kit</artifactId>

--- a/s1tbx-kit/pom.xml
+++ b/s1tbx-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s1tbx</artifactId>
         <groupId>org.esa.s1tbx</groupId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-kit</artifactId>

--- a/s1tbx-kit/pom.xml
+++ b/s1tbx-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s1tbx</artifactId>
         <groupId>org.esa.s1tbx</groupId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-kit</artifactId>

--- a/s1tbx-kit/pom.xml
+++ b/s1tbx-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s1tbx</artifactId>
         <groupId>org.esa.s1tbx</groupId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <artifactId>s1tbx-kit</artifactId>

--- a/s1tbx-op-analysis-ui/pom.xml
+++ b/s1tbx-op-analysis-ui/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Analysis Tools UI</name>

--- a/s1tbx-op-analysis-ui/pom.xml
+++ b/s1tbx-op-analysis-ui/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <name>S1TBX Analysis Tools UI</name>

--- a/s1tbx-op-analysis-ui/pom.xml
+++ b/s1tbx-op-analysis-ui/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Analysis Tools UI</name>

--- a/s1tbx-op-analysis-ui/pom.xml
+++ b/s1tbx-op-analysis-ui/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Analysis Tools UI</name>

--- a/s1tbx-op-analysis-ui/pom.xml
+++ b/s1tbx-op-analysis-ui/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <name>S1TBX Analysis Tools UI</name>

--- a/s1tbx-op-analysis-ui/pom.xml
+++ b/s1tbx-op-analysis-ui/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Analysis Tools UI</name>

--- a/s1tbx-op-analysis-ui/pom.xml
+++ b/s1tbx-op-analysis-ui/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <name>S1TBX Analysis Tools UI</name>

--- a/s1tbx-op-calibration-ui/pom.xml
+++ b/s1tbx-op-calibration-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-calibration-ui</artifactId>

--- a/s1tbx-op-calibration-ui/pom.xml
+++ b/s1tbx-op-calibration-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <artifactId>s1tbx-op-calibration-ui</artifactId>

--- a/s1tbx-op-calibration-ui/pom.xml
+++ b/s1tbx-op-calibration-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-calibration-ui</artifactId>

--- a/s1tbx-op-calibration-ui/pom.xml
+++ b/s1tbx-op-calibration-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <artifactId>s1tbx-op-calibration-ui</artifactId>

--- a/s1tbx-op-calibration-ui/pom.xml
+++ b/s1tbx-op-calibration-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-calibration-ui</artifactId>

--- a/s1tbx-op-calibration-ui/pom.xml
+++ b/s1tbx-op-calibration-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-calibration-ui</artifactId>

--- a/s1tbx-op-calibration-ui/pom.xml
+++ b/s1tbx-op-calibration-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <artifactId>s1tbx-op-calibration-ui</artifactId>

--- a/s1tbx-op-calibration/pom.xml
+++ b/s1tbx-op-calibration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-calibration</artifactId>

--- a/s1tbx-op-calibration/pom.xml
+++ b/s1tbx-op-calibration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <artifactId>s1tbx-op-calibration</artifactId>

--- a/s1tbx-op-calibration/pom.xml
+++ b/s1tbx-op-calibration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-calibration</artifactId>

--- a/s1tbx-op-calibration/pom.xml
+++ b/s1tbx-op-calibration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <artifactId>s1tbx-op-calibration</artifactId>

--- a/s1tbx-op-calibration/pom.xml
+++ b/s1tbx-op-calibration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <artifactId>s1tbx-op-calibration</artifactId>

--- a/s1tbx-op-calibration/pom.xml
+++ b/s1tbx-op-calibration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-calibration</artifactId>

--- a/s1tbx-op-calibration/pom.xml
+++ b/s1tbx-op-calibration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-calibration</artifactId>

--- a/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/RemoveAntennaPatternOp.java
+++ b/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/RemoveAntennaPatternOp.java
@@ -33,6 +33,7 @@ import org.esa.snap.core.gpf.annotations.TargetProduct;
 import org.esa.snap.core.util.ProductUtils;
 import org.esa.snap.engine_utilities.datamodel.AbstractMetadata;
 import org.esa.snap.engine_utilities.datamodel.Unit;
+import org.esa.snap.engine_utilities.gpf.InputProductValidator;
 import org.esa.snap.engine_utilities.gpf.OperatorUtils;
 
 import java.util.ArrayList;
@@ -76,6 +77,10 @@ public class RemoveAntennaPatternOp extends Operator {
     public void initialize() throws OperatorException {
 
         try {
+            final InputProductValidator validator = new InputProductValidator(sourceProduct);
+            validator.checkIfSARProduct();
+            validator.checkMission(new String[] {"ENVISAT", "ERS-1", "ERS-2"});
+
             getProductType();
 
             getMultilookFlag();

--- a/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/RemoveGRDBorderNoiseOp.java
+++ b/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/RemoveGRDBorderNoiseOp.java
@@ -44,6 +44,7 @@ import org.esa.snap.engine_utilities.gpf.TileIndex;
 import org.esa.snap.engine_utilities.util.Maths;
 
 import java.awt.*;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -287,7 +288,7 @@ public final class RemoveGRDBorderNoiseOp extends Operator {
     /**
      * Compute noise scaling factor.
      */
-    private void computeNoiseScalingFactor() {
+    private void computeNoiseScalingFactor() throws IOException {
 
         if (version < 2.50) {
             final String acquisitionMode = absRoot.getAttributeString(AbstractMetadata.ACQUISITION_MODE);
@@ -316,7 +317,7 @@ public final class RemoveGRDBorderNoiseOp extends Operator {
     /**
      * Get the first element in DN vector from the original product metadata.
      */
-    private double getDN0() {
+    private double getDN0() throws IOException {
 
         String[] selectedPols = {coPolarization};
         Sentinel1Calibrator.CalibrationInfo[] calibration = Sentinel1Calibrator.getCalibrationVectors(

--- a/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/RemoveGRDBorderNoiseOp.java
+++ b/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/RemoveGRDBorderNoiseOp.java
@@ -86,7 +86,7 @@ public final class RemoveGRDBorderNoiseOp extends Operator {
     private int sourceImageHeight = 0;
     private double version = 0.0f;
     private double scalingFactor = 0.0;
-    private double noDataValue = 0;
+    private Double noDataValue = 0.0;
     private String coPolarization = null;
     private Sentinel1Utils.NoiseVector noiseVector = null;
     private double[] noiseLUT = null;
@@ -479,7 +479,7 @@ public final class RemoveGRDBorderNoiseOp extends Operator {
 
                     if (testPixel) {
                         coPolDataValue = coPolData.getElemDoubleAt(srcIdx);
-                        if (coPolDataValue == noDataValue) {
+                        if (noDataValue.equals(coPolDataValue)) {
                             continue;
                         }
 

--- a/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/Sentinel1RemoveThermalNoiseOp.java
+++ b/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/Sentinel1RemoveThermalNoiseOp.java
@@ -36,6 +36,7 @@ import org.esa.snap.engine_utilities.gpf.TileIndex;
 import org.esa.snap.engine_utilities.util.Maths;
 
 import java.awt.*;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -194,10 +195,16 @@ public final class Sentinel1RemoveThermalNoiseOp extends Operator {
      */
     public static ThermalNoiseInfo[] getThermalNoiseVectors(final MetadataElement origMetadataRoot,
                                                             final List<String> selectedPolList,
-                                                            final int numOfSubSwath) {
+                                                            final int numOfSubSwath) throws IOException {
 
         final ThermalNoiseInfo[] noise = new ThermalNoiseInfo[numOfSubSwath * selectedPolList.size()];
+        if(origMetadataRoot == null) {
+            throw new IOException("Unable to find original product metadata");
+        }
         final MetadataElement noiseElem = origMetadataRoot.getElement("noise");
+        if(noiseElem == null) {
+            throw new IOException("Unable to find noise element in original product metadata");
+        }
         final MetadataElement[] noiseDataSetListElem = noiseElem.getElements();
 
         int dataSetIndex = 0;
@@ -269,7 +276,7 @@ public final class Sentinel1RemoveThermalNoiseOp extends Operator {
     /**
      * Get calibration vectors from the original product metadata.
      */
-    private void getCalibrationVectors() {
+    private void getCalibrationVectors() throws IOException {
 
         calibration = Sentinel1Calibrator.getCalibrationVectors(
                 sourceProduct,

--- a/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/calibrators/ALOSCalibrator.java
+++ b/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/calibrators/ALOSCalibrator.java
@@ -193,8 +193,9 @@ public class ALOSCalibrator extends BaseCalibrator implements Calibrator {
         final int maxY = y0 + h;
         final int maxX = x0 + w;
 
-        double sigma, dn, dn2, i, q, phaseTerm = 0.0;
+        double sigma, dn, i, q, phaseTerm = 0.0;
         int srcIdx, tgtIdx;
+        final Double nodatavalue = targetBand.getNoDataValue();
 
         for (int y = y0; y < maxY; ++y) {
             srcIndex.calculateStride(y);
@@ -204,27 +205,32 @@ public class ALOSCalibrator extends BaseCalibrator implements Calibrator {
                 srcIdx = srcIndex.getIndex(x);
                 tgtIdx = tgtIndex.getIndex(x);
 
+                dn = srcData1.getElemDoubleAt(srcIdx);
+                if(nodatavalue.equals(dn)) {
+                    trgData.setElemDoubleAt(tgtIdx, nodatavalue);
+                    continue;
+                }
+
                 if (srcBandUnit == Unit.UnitType.AMPLITUDE) {
-                    dn = srcData1.getElemDoubleAt(srcIdx);
-                    dn2 = dn * dn;
+                    dn *= dn;
                 } else if (srcBandUnit == Unit.UnitType.INTENSITY) {
-                    dn2 = srcData1.getElemDoubleAt(srcIdx);
+
                 } else if (srcBandUnit == Unit.UnitType.REAL) {
-                    i = srcData1.getElemDoubleAt(srcIdx);
+                    i = dn;
                     q = srcData2.getElemDoubleAt(srcIdx);
-                    dn2 = i * i + q * q;
+                    dn = i * i + q * q;
                     if (tgtBandUnit == Unit.UnitType.REAL) {
-                        phaseTerm = i / Math.sqrt(dn2);
+                        phaseTerm = i / Math.sqrt(dn);
                     } else if (tgtBandUnit == Unit.UnitType.IMAGINARY) {
-                        phaseTerm = q / Math.sqrt(dn2);
+                        phaseTerm = q / Math.sqrt(dn);
                     }
                 } else if (srcBandUnit == Unit.UnitType.INTENSITY_DB) {
-                    dn2 = FastMath.pow(10, srcData1.getElemDoubleAt(srcIdx) / 10.0); // convert dB to linear scale
+                    dn = FastMath.pow(10, dn / 10.0); // convert dB to linear scale
                 } else {
                     throw new OperatorException("ALOS Calibration: unhandled unit");
                 }
 
-                sigma = dn2 * calibrationFactor;
+                sigma = dn * calibrationFactor;
 
                 if (isComplex && outputImageInComplex) {
                     sigma = Math.sqrt(sigma)*phaseTerm;

--- a/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/calibrators/ASARCalibrator.java
+++ b/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/calibrators/ASARCalibrator.java
@@ -370,6 +370,7 @@ public class ASARCalibrator extends BaseCalibrator implements Calibrator {
     static int getNumOfRecordsInMainProcParam(Product sourceProduct) throws OperatorException {
 
         final MetadataElement origRoot = AbstractMetadata.getOriginalProductMetadata(sourceProduct);
+
         final MetadataElement dsdElem = origRoot.getElement("DSD");
         if (dsdElem == null) {
             throw new OperatorException("DSD not found");

--- a/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/calibrators/ASARCalibrator.java
+++ b/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/calibrators/ASARCalibrator.java
@@ -931,8 +931,9 @@ public class ASARCalibrator extends BaseCalibrator implements Calibrator {
             }
         }
 
-        double sigma, dn, dn2, i, q, phaseTerm = 0.0;
+        double sigma, dn, i, q, phaseTerm = 0.0;
         final double theCalibrationFactor = newCalibrationConstant[prodBand];
+        final Double nodatavalue = targetBand.getNoDataValue();
 
         int srcIdx, tgtIdx;
         for (int y = y0, yy = 0; y < maxY; ++y, ++yy) {
@@ -949,22 +950,27 @@ public class ASARCalibrator extends BaseCalibrator implements Calibrator {
                 srcIdx = srcIndex.getIndex(x);
                 tgtIdx = tgtIndex.getIndex(x);
 
+                dn = srcData1.getElemDoubleAt(srcIdx);
+                if(nodatavalue.equals(dn)) {
+                    trgData.setElemDoubleAt(tgtIdx, nodatavalue);
+                    continue;
+                }
+
                 if (srcBandUnit == Unit.UnitType.AMPLITUDE) {
-                    dn = srcData1.getElemDoubleAt(srcIdx);
-                    dn2 = dn * dn;
+                    dn *= dn;
                 } else if (srcBandUnit == Unit.UnitType.INTENSITY) {
-                    dn2 = srcData1.getElemDoubleAt(srcIdx);
+
                 } else if (srcBandUnit == Unit.UnitType.REAL) {
-                    i = srcData1.getElemDoubleAt(srcIdx);
+                    i = dn;
                     q = srcData2.getElemDoubleAt(srcIdx);
-                    dn2 = i * i + q * q;
+                    dn = i * i + q * q;
                     if (tgtBandUnit == Unit.UnitType.REAL) {
-                        phaseTerm = i / Math.sqrt(dn2);
+                        phaseTerm = i / Math.sqrt(dn);
                     } else if (tgtBandUnit == Unit.UnitType.IMAGINARY) {
-                        phaseTerm = q / Math.sqrt(dn2);
+                        phaseTerm = q / Math.sqrt(dn);
                     }
                 } else if (srcBandUnit == Unit.UnitType.INTENSITY_DB) {
-                    dn2 = FastMath.pow(10, srcData1.getElemDoubleAt(srcIdx) / 10.0); // convert dB to linear scale
+                    dn = FastMath.pow(10, dn / 10.0); // convert dB to linear scale
                 } else {
                     throw new OperatorException("ASAR Calibration: unhandled unit");
                 }
@@ -985,7 +991,7 @@ public class ASARCalibrator extends BaseCalibrator implements Calibrator {
                     calFactor /= targetTileNewAntPat[yy][xx];  // see Andrea's email dated Nov. 11, 2008
                 }
 
-                sigma = dn2*calFactor;
+                sigma = dn*calFactor;
 
                 if (isComplex && outputImageInComplex) {
                     sigma = Math.sqrt(sigma)*phaseTerm;

--- a/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/calibrators/CosmoSkymedCalibrator.java
+++ b/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/calibrators/CosmoSkymedCalibrator.java
@@ -307,11 +307,12 @@ public class CosmoSkymedCalibrator extends BaseCalibrator implements Calibrator 
         final int maxY = y0 + h;
         final int maxX = x0 + w;
 
-        double sigma, dn, dn2, i, q, phaseTerm = 0.0;
+        double sigma, dn, i, q, phaseTerm = 0.0;
         int srcIdx, tgtIdx;
         final double powFactor = FastMath.pow(referenceSlantRange, 2 * referenceSlantRangeExp);
         final double sinRefIncidenceAngle = FastMath.sin(referenceIncidenceAngle);
         final double rescaleCalFactor = rescalingFactor * rescalingFactor * Ks;
+        final Double nodatavalue = targetBand.getNoDataValue();
 
         for (int y = y0; y < maxY; ++y) {
             srcIndex.calculateStride(y);
@@ -321,22 +322,27 @@ public class CosmoSkymedCalibrator extends BaseCalibrator implements Calibrator 
                 srcIdx = srcIndex.getIndex(x);
                 tgtIdx = tgtIndex.getIndex(x);
 
+                dn = srcData1.getElemDoubleAt(srcIdx);
+                if(nodatavalue.equals(dn)) {
+                    trgData.setElemDoubleAt(tgtIdx, nodatavalue);
+                    continue;
+                }
+
                 if (srcBandUnit == Unit.UnitType.AMPLITUDE) {
-                    dn = srcData1.getElemDoubleAt(srcIdx);
-                    dn2 = dn * dn;
+                    dn *= dn;
                 } else if (srcBandUnit == Unit.UnitType.INTENSITY) {
-                    dn2 = srcData1.getElemDoubleAt(srcIdx);
+
                 } else if (srcBandUnit == Unit.UnitType.REAL) {
-                    i = srcData1.getElemDoubleAt(srcIdx);
+                    i = dn;
                     q = srcData2.getElemDoubleAt(srcIdx);
-                    dn2 = i * i + q * q;
+                    dn = i * i + q * q;
                     if (tgtBandUnit == Unit.UnitType.REAL) {
-                        phaseTerm = i / Math.sqrt(dn2);
+                        phaseTerm = i / Math.sqrt(dn);
                     } else if (tgtBandUnit == Unit.UnitType.IMAGINARY) {
-                        phaseTerm = q / Math.sqrt(dn2);
+                        phaseTerm = q / Math.sqrt(dn);
                     }
                 } else if (srcBandUnit == Unit.UnitType.INTENSITY_DB) {
-                    dn2 = FastMath.pow(10, srcData1.getElemDoubleAt(srcIdx) / 10.0); // convert dB to linear scale
+                    dn = FastMath.pow(10, dn / 10.0); // convert dB to linear scale
                 } else {
                     throw new OperatorException("CosmoSkymed Calibration: unhandled unit");
                 }
@@ -350,7 +356,7 @@ public class CosmoSkymedCalibrator extends BaseCalibrator implements Calibrator 
 
                 calFactor /= rescaleCalFactor;
 
-                sigma = dn2 * calFactor;
+                sigma = dn * calFactor;
 
                 if (isComplex && outputImageInComplex) {
                     sigma = Math.sqrt(sigma) * phaseTerm;

--- a/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/calibrators/Radarsat2Calibrator.java
+++ b/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/calibrators/Radarsat2Calibrator.java
@@ -225,8 +225,9 @@ public class Radarsat2Calibrator extends BaseCalibrator implements Calibrator {
         final int maxY = y0 + h;
         final int maxX = x0 + w;
 
-        double sigma = 0.0, dn, dn2, i, q, phaseTerm = 0.0;
+        double sigma = 0.0, dn, i, q, phaseTerm = 0.0;
         int srcIdx, tgtIdx;
+        final Double nodatavalue = targetBand.getNoDataValue();
 
         for (int y = y0; y < maxY; ++y) {
             srcIndex.calculateStride(y);
@@ -236,35 +237,40 @@ public class Radarsat2Calibrator extends BaseCalibrator implements Calibrator {
                 srcIdx = srcIndex.getIndex(x);
                 tgtIdx = tgtIndex.getIndex(x);
 
+                dn = srcData1.getElemDoubleAt(srcIdx);
+                if(nodatavalue.equals(dn)) {
+                    trgData.setElemDoubleAt(tgtIdx, nodatavalue);
+                    continue;
+                }
+
                 if (srcBandUnit == Unit.UnitType.AMPLITUDE) {
-                    dn = srcData1.getElemDoubleAt(srcIdx);
-                    dn2 = dn * dn;
+                    dn *= dn;
                 } else if (srcBandUnit == Unit.UnitType.INTENSITY) {
-                    dn2 = srcData1.getElemDoubleAt(srcIdx);
+
                 } else if (srcBandUnit == Unit.UnitType.REAL) {
-                    i = srcData1.getElemDoubleAt(srcIdx);
+                    i = dn;
                     q = srcData2.getElemDoubleAt(srcIdx);
-                    dn2 = i * i + q * q;
+                    dn = i * i + q * q;
                     if (tgtBandUnit == Unit.UnitType.REAL) {
-                        phaseTerm = i / Math.sqrt(dn2);
+                        phaseTerm = i / Math.sqrt(dn);
                     } else if (tgtBandUnit == Unit.UnitType.IMAGINARY) {
-                        phaseTerm = q / Math.sqrt(dn2);
+                        phaseTerm = q / Math.sqrt(dn);
                     }
                 } else if (srcBandUnit == Unit.UnitType.INTENSITY_DB) {
-                    dn2 = FastMath.pow(10, srcData1.getElemDoubleAt(srcIdx) / 10.0); // convert dB to linear scale
+                    dn = FastMath.pow(10, dn / 10.0); // convert dB to linear scale
                 } else {
                     throw new OperatorException("RadarSat2 Calibration: unhandled unit");
                 }
 
                 if (isSLC) {
                     if (gains != null) {
-                        sigma = dn2 / (gains[x + subsetOffsetX] * gains[x + subsetOffsetX]);
+                        sigma = dn / (gains[x + subsetOffsetX] * gains[x + subsetOffsetX]);
                         if (outputImageInComplex) {
                             sigma = Math.sqrt(sigma)*phaseTerm;
                         }
                     }
                 } else {
-                    sigma = dn2 + offset;
+                    sigma = dn + offset;
                     if (gains != null) {
                         sigma /= gains[x + subsetOffsetX];
                     }

--- a/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/calibrators/Sentinel1Calibrator.java
+++ b/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/calibrators/Sentinel1Calibrator.java
@@ -38,6 +38,7 @@ import org.esa.snap.engine_utilities.gpf.TileIndex;
 
 import java.awt.*;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -167,7 +168,7 @@ public final class Sentinel1Calibrator extends BaseCalibrator implements Calibra
         return (version < 2.34f);
     }
 
-    private void getVectors() {
+    private void getVectors() throws IOException {
 
         boolean getSigmaLUT = outputSigmaBand;
         boolean getBetaLUT = outputBetaBand;
@@ -196,11 +197,17 @@ public final class Sentinel1Calibrator extends BaseCalibrator implements Calibra
     public static CalibrationInfo[] getCalibrationVectors(
             final Product sourceProduct, final java.util.List<String> selectedPolList,
             final boolean getSigmaLUT, final boolean getBetaLUT, final boolean getGammaLUT,
-            final boolean getDNLUT) {
+            final boolean getDNLUT) throws IOException {
 
         final List<CalibrationInfo> calibrationInfoList = new ArrayList<>();
         final MetadataElement origProdRoot = AbstractMetadata.getOriginalProductMetadata(sourceProduct);
+        if(origProdRoot == null) {
+            throw new IOException("Unable to find original product metadata");
+        }
         final MetadataElement calibrationElem = origProdRoot.getElement("calibration");
+        if(calibrationElem == null) {
+            throw new IOException("Unable to find calibration element in original product metadata");
+        }
         final MetadataElement[] calibrationDataSetListElem = calibrationElem.getElements();
 
         for (MetadataElement dataSetListElem : calibrationDataSetListElem) {

--- a/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/calibrators/Sentinel1Calibrator.java
+++ b/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/calibrators/Sentinel1Calibrator.java
@@ -548,8 +548,10 @@ public final class Sentinel1Calibrator extends BaseCalibrator implements Calibra
             final CalibrationInfo calInfo = targetBandToCalInfo.get(targetBandName);
             final CALTYPE calType = getCalibrationType(targetBandName);
 
-            double dn = 0.0, dn2, i, q, muX, lutVal, retroLutVal = 1.0, calValue, calibrationFactor, phaseTerm = 0.0;
+            double dn = 0.0, i, q, muX, lutVal, retroLutVal = 1.0, calValue, calibrationFactor, phaseTerm = 0.0;
             int srcIdx;
+            final Double nodatavalue = targetBand.getNoDataValue();
+
             for (int y = y0; y < maxY; ++y) {
                 srcIndex.calculateStride(y);
                 trgIndex.calculateStride(y);
@@ -573,6 +575,12 @@ public final class Sentinel1Calibrator extends BaseCalibrator implements Calibra
                 for (int x = x0; x < maxX; ++x) {
                     srcIdx = srcIndex.getIndex(x);
 
+                    dn = srcData1.getElemDoubleAt(srcIdx);
+                    if(nodatavalue.equals(dn)) {
+                        tgtData.setElemDoubleAt(trgIndex.getIndex(x), nodatavalue);
+                        continue;
+                    }
+
                     final int pixelIdx = calVec.getPixelIndex(x);
                     muX = (x - vec0Pixels[pixelIdx]) / (double)(vec0Pixels[pixelIdx + 1] - vec0Pixels[pixelIdx]);
 
@@ -582,36 +590,29 @@ public final class Sentinel1Calibrator extends BaseCalibrator implements Calibra
                     calibrationFactor = 1.0 / (lutVal*lutVal);
 
                     if (srcBandUnit == Unit.UnitType.AMPLITUDE) {
-                        dn = srcData1.getElemDoubleAt(srcIdx);
-                        if (dn == noDataValue) continue;
-                        dn2 = dn * dn;
+                        dn *= dn;
                     } else if (srcBandUnit == Unit.UnitType.INTENSITY) {
-                        dn2 = srcData1.getElemDoubleAt(srcIdx);
-                        if (dn2 == noDataValue) continue;
                         if (dataType != null) {
                             retroLutVal = (1 - muY) * ((1 - muX) * retroVec0LUT[pixelIdx] + muX * retroVec0LUT[pixelIdx + 1]) +
                                     muY * ((1 - muX) * retroVec1LUT[pixelIdx] + muX * retroVec1LUT[pixelIdx + 1]);
                         }
                         calibrationFactor *= retroLutVal;
                     } else if (srcBandUnit == Unit.UnitType.REAL) {
-                        i = srcData1.getElemDoubleAt(srcIdx);
+                        i = dn;
                         q = srcData2.getElemDoubleAt(srcIdx);
-                        if (i == noDataValue && q == noDataValue) continue;
-                        dn2 = i * i + q * q;
+                        dn = i * i + q * q;
                         if (tgtBandUnit == Unit.UnitType.REAL) {
-                            phaseTerm = i / Math.sqrt(dn2);
+                            phaseTerm = i / Math.sqrt(dn);
                         } else if (tgtBandUnit == Unit.UnitType.IMAGINARY) {
-                            phaseTerm = q / Math.sqrt(dn2);
+                            phaseTerm = q / Math.sqrt(dn);
                         }
                     } else if (srcBandUnit == Unit.UnitType.INTENSITY_DB) {
-                        dn = srcData1.getElemDoubleAt(srcIdx);
-                        if (dn == noDataValue) continue;
-                        dn2 = FastMath.pow(10, dn / 10.0); // convert dB to linear scale
+                        dn = FastMath.pow(10, dn / 10.0); // convert dB to linear scale
                     } else {
                         throw new OperatorException("Sentinel-1 Calibration: unhandled unit");
                     }
 
-                    calValue = dn2 * calibrationFactor;
+                    calValue = dn * calibrationFactor;
 
                     if (isComplex && outputImageInComplex) {
                         calValue = Math.sqrt(calValue)*phaseTerm;

--- a/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/calibrators/TerraSARXCalibrator.java
+++ b/s1tbx-op-calibration/src/main/java/org/esa/s1tbx/calibration/gpf/calibrators/TerraSARXCalibrator.java
@@ -398,8 +398,9 @@ public class TerraSARXCalibrator extends BaseCalibrator implements Calibrator {
         final int maxY = y0 + h;
         final int maxX = x0 + w;
 
-        double sigma, dn, dn2, i, q, phaseTerm = 0.0;
+        double sigma, dn, i, q, phaseTerm = 0.0;
         int srcIdx, tgtIdx;
+        final Double nodatavalue = targetBand.getNoDataValue();
 
         for (int y = y0; y < maxY; ++y) {
             srcIndex.calculateStride(y);
@@ -409,22 +410,27 @@ public class TerraSARXCalibrator extends BaseCalibrator implements Calibrator {
                 srcIdx = srcIndex.getIndex(x);
                 tgtIdx = tgtIndex.getIndex(x);
 
+                dn = srcData1.getElemDoubleAt(srcIdx);
+                if(nodatavalue.equals(dn)) {
+                    trgData.setElemDoubleAt(tgtIdx, nodatavalue);
+                    continue;
+                }
+
                 if (srcBandUnit == Unit.UnitType.AMPLITUDE) {
-                    dn = srcData1.getElemDoubleAt(srcIdx);
-                    dn2 = dn * dn;
+                    dn *= dn;
                 } else if (srcBandUnit == Unit.UnitType.INTENSITY) {
-                    dn2 = srcData1.getElemDoubleAt(srcIdx);
+
                 } else if (srcBandUnit == Unit.UnitType.REAL) {
-                    i = srcData1.getElemDoubleAt(srcIdx);
+                    i = dn;
                     q = srcData2.getElemDoubleAt(srcIdx);
-                    dn2 = i * i + q * q;
+                    dn = i * i + q * q;
                     if (tgtBandUnit == Unit.UnitType.REAL) {
-                        phaseTerm = i / Math.sqrt(dn2);
+                        phaseTerm = i / Math.sqrt(dn);
                     } else if (tgtBandUnit == Unit.UnitType.IMAGINARY) {
-                        phaseTerm = q / Math.sqrt(dn2);
+                        phaseTerm = q / Math.sqrt(dn);
                     }
                 } else if (srcBandUnit == Unit.UnitType.INTENSITY_DB) {
-                    dn2 = FastMath.pow(10, srcData1.getElemDoubleAt(srcIdx) / 10.0); // convert dB to linear scale
+                    dn = FastMath.pow(10, dn / 10.0); // convert dB to linear scale
                 } else {
                     throw new OperatorException("TerraSAR-X Calibration: unhandled unit");
                 }
@@ -438,9 +444,9 @@ public class TerraSARXCalibrator extends BaseCalibrator implements Calibrator {
                 }
 
                 if (noiseCorrectedFlag) {
-                    sigma = Ks * dn2 * FastMath.sin(inciAng);
+                    sigma = Ks * dn * FastMath.sin(inciAng);
                 } else {
-                    sigma = Ks * Math.abs(dn2 - tileNoise[y - y0][x - x0]) * FastMath.sin(inciAng);
+                    sigma = Ks * Math.abs(dn - tileNoise[y - y0][x - x0]) * FastMath.sin(inciAng);
                 }
 
                 if (isComplex && outputImageInComplex) {

--- a/s1tbx-op-feature-extraction-ui/pom.xml
+++ b/s1tbx-op-feature-extraction-ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-feature-extraction-ui</artifactId>

--- a/s1tbx-op-feature-extraction-ui/pom.xml
+++ b/s1tbx-op-feature-extraction-ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-feature-extraction-ui</artifactId>

--- a/s1tbx-op-feature-extraction-ui/pom.xml
+++ b/s1tbx-op-feature-extraction-ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <artifactId>s1tbx-op-feature-extraction-ui</artifactId>

--- a/s1tbx-op-feature-extraction-ui/pom.xml
+++ b/s1tbx-op-feature-extraction-ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <artifactId>s1tbx-op-feature-extraction-ui</artifactId>

--- a/s1tbx-op-feature-extraction-ui/pom.xml
+++ b/s1tbx-op-feature-extraction-ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <artifactId>s1tbx-op-feature-extraction-ui</artifactId>

--- a/s1tbx-op-feature-extraction-ui/pom.xml
+++ b/s1tbx-op-feature-extraction-ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-feature-extraction-ui</artifactId>

--- a/s1tbx-op-feature-extraction-ui/pom.xml
+++ b/s1tbx-op-feature-extraction-ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-feature-extraction-ui</artifactId>

--- a/s1tbx-op-feature-extraction/pom.xml
+++ b/s1tbx-op-feature-extraction/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-feature-extraction</artifactId>

--- a/s1tbx-op-feature-extraction/pom.xml
+++ b/s1tbx-op-feature-extraction/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-feature-extraction</artifactId>

--- a/s1tbx-op-feature-extraction/pom.xml
+++ b/s1tbx-op-feature-extraction/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <artifactId>s1tbx-op-feature-extraction</artifactId>

--- a/s1tbx-op-feature-extraction/pom.xml
+++ b/s1tbx-op-feature-extraction/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <artifactId>s1tbx-op-feature-extraction</artifactId>

--- a/s1tbx-op-feature-extraction/pom.xml
+++ b/s1tbx-op-feature-extraction/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <artifactId>s1tbx-op-feature-extraction</artifactId>

--- a/s1tbx-op-feature-extraction/pom.xml
+++ b/s1tbx-op-feature-extraction/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-feature-extraction</artifactId>

--- a/s1tbx-op-feature-extraction/pom.xml
+++ b/s1tbx-op-feature-extraction/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-feature-extraction</artifactId>

--- a/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/ChangeDetectionOp.java
+++ b/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/ChangeDetectionOp.java
@@ -224,8 +224,8 @@ public class ChangeDetectionOp extends Operator {
             final Tile denominatorTile = getSourceTile(denominatorBand, targetRectangle);
             final ProductData nominatorData = nominatorTile.getDataBuffer();
             final ProductData denominatorData = denominatorTile.getDataBuffer();
-            final double noDataValueN = nominatorBand.getNoDataValue();
-            final double noDataValueD = denominatorBand.getNoDataValue();
+            final Double noDataValueN = nominatorBand.getNoDataValue();
+            final Double noDataValueD = denominatorBand.getNoDataValue();
 
             final Band targetRatioBand = targetProduct.getBand(ratioBandName);
             final Tile targetRatioTile = targetTiles.get(targetRatioBand);
@@ -247,7 +247,7 @@ public class ChangeDetectionOp extends Operator {
 
                     final double vN = nominatorData.getElemDoubleAt(srcIdx);
                     final double vD = denominatorData.getElemDoubleAt(srcIdx);
-                    if (vN == noDataValueN || vD == noDataValueD || vN <= 0.0 || vD <= 0.0) {
+                    if (noDataValueN.equals(vN) || noDataValueD.equals(vD) || vN <= 0.0 || vD <= 0.0) {
                         ratioData.setElemFloatAt(trgIdx, 0.0f);
                         continue;
                     }

--- a/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/forest/ForestAreaDetectionOp.java
+++ b/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/forest/ForestAreaDetectionOp.java
@@ -222,8 +222,8 @@ public class ForestAreaDetectionOp extends Operator {
             final ProductData denominatorData = denominatorTile.getDataBuffer();
             final String nominatorBandUnit = nominatorBand.getUnit();
             final String denominatorBandUnit = denominatorBand.getUnit();
-            final double noDataValueN = nominatorBand.getNoDataValue();
-            final double noDataValueD = denominatorBand.getNoDataValue();
+            final Double noDataValueN = nominatorBand.getNoDataValue();
+            final Double noDataValueD = denominatorBand.getNoDataValue();
 
             final Band targetRatioBand = targetProduct.getBand(RATIO_BAND_NAME);
             final Tile targetRatioTile = targetTiles.get(targetRatioBand);
@@ -249,7 +249,7 @@ public class ForestAreaDetectionOp extends Operator {
 
                     final double vN = nominatorData.getElemDoubleAt(srcIdx);
                     final double vD = denominatorData.getElemDoubleAt(srcIdx);
-                    if (vN == noDataValueN || vD == noDataValueD) {
+                    if (noDataValueN.equals(vN) || noDataValueD.equals(vD)) {
                         //maskData.setElemIntAt(trgIdx, -1);
                         ratioData.setElemFloatAt(trgIdx, 0.0f);
                         continue;
@@ -258,7 +258,7 @@ public class ForestAreaDetectionOp extends Operator {
                     final double vRatio = computeRatio(tx, ty, windowSize, nominatorTile, nominatorData, denominatorTile,
                             denominatorData, nominatorBandUnit, denominatorBandUnit, noDataValueN, noDataValueD);
 
-                    if (vRatio == noDataValueN || vRatio == noDataValueD) {
+                    if (noDataValueN.equals(vRatio) || noDataValueD.equals(vRatio)) {
                         //maskData.setElemIntAt(trgIdx, -1);
                         ratioData.setElemFloatAt(trgIdx, 0.0f);
                         continue;

--- a/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/oceantools/AdaptiveThresholdingOp.java
+++ b/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/oceantools/AdaptiveThresholdingOp.java
@@ -241,7 +241,7 @@ public class AdaptiveThresholdingOp extends Operator {
             final String srcBandName = targetBandNameToSourceBandName.get(targetBand.getName());
             final Band sourceBand = sourceProduct.getBand(srcBandName);
             final Tile sourceTile = getSourceTile(sourceBand, sourceTileRectangle);
-            final double noDataValue = sourceBand.getNoDataValue();
+            final Double noDataValue = sourceBand.getNoDataValue();
 
             final TileIndex trgIndex = new TileIndex(targetTile);
             final TileIndex srcIndex = new TileIndex(sourceTile);    // src and trg tile are different size
@@ -254,7 +254,7 @@ public class AdaptiveThresholdingOp extends Operator {
                 for (int tx = tx0; tx < maxx; tx++) {
 
                     final double targetMean = computeTargetMean(tx, ty, sourceTile, noDataValue);
-                    if (targetMean == noDataValue) {
+                    if (noDataValue.equals(targetMean)) {
                         trgData.setElemIntAt(trgIndex.getIndex(tx), 0);
                         continue;
                     }
@@ -281,11 +281,11 @@ public class AdaptiveThresholdingOp extends Operator {
      * @param noDataValue
      * @return The mena value.
      */
-    private double computeTargetMean(final int tx, final int ty, final Tile sourceTile, final double noDataValue) {
+    private double computeTargetMean(final int tx, final int ty, final Tile sourceTile, final Double noDataValue) {
 
         final ProductData srcData = sourceTile.getDataBuffer();
         final double v = srcData.getElemDoubleAt(sourceTile.getDataBufferIndex(tx, ty));
-        if (v == noDataValue) {
+        if (noDataValue.equals(v)) {
             return noDataValue;
         }
 
@@ -311,7 +311,7 @@ public class AdaptiveThresholdingOp extends Operator {
             final int stride = ((y - tileMinY) * tileStride) + tileOffset;
             for (int x = x0; x < maxx; x++) {
                 final double val = srcData.getElemDoubleAt((x - tileMinX) + stride);
-                if (val == noDataValue) {
+                if (noDataValue.equals(val)) {
                     return noDataValue;
                 } else {
                     mean += val;
@@ -328,10 +328,10 @@ public class AdaptiveThresholdingOp extends Operator {
      * @param tx          The x coordinate of the central point of the background window.
      * @param ty          The y coordinate of the central point of the background window.
      * @param sourceTile  The source image tile.
-     * @param noDataValue
+     * @param noDataValue no data value
      * @return The std value.
      */
-    private double computeBackgroundThreshold(final int tx, final int ty, final Tile sourceTile, final double noDataValue) {
+    private double computeBackgroundThreshold(final int tx, final int ty, final Tile sourceTile, final Double noDataValue) {
 
         final int x0 = Math.max(tx - halfBackgroundWindowSize, 0);
         final int y0 = Math.max(ty - halfBackgroundWindowSize, 0);
@@ -358,7 +358,7 @@ public class AdaptiveThresholdingOp extends Operator {
             for (int x = x0; x < maxx; x++) {
                 if (yGtrHalfGuard || Math.abs(x - tx) > halfGuardWindowSize) {
                     val = srcData.getElemDoubleAt((x - tileMinX) + stride);
-                    if (val == noDataValue) {
+                    if (noDataValue.equals(val)) {
                         return Double.MAX_VALUE;
                     } else {
                         sum += val;

--- a/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/oceantools/ObjectDiscriminationOp.java
+++ b/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/oceantools/ObjectDiscriminationOp.java
@@ -191,6 +191,8 @@ public class ObjectDiscriminationOp extends Operator {
                         sourceImageWidth,
                         sourceImageHeight);
 
+                targetBand.setNoDataValueUsed(true);
+                targetBand.setNoDataValue(srcBand.getNoDataValue());
                 targetBand.setUnit(srcBand.getUnit());
                 targetProduct.addBand(targetBand);
 

--- a/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/oceantools/OilSpillClusteringOp.java
+++ b/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/oceantools/OilSpillClusteringOp.java
@@ -138,8 +138,7 @@ public class OilSpillClusteringOp extends Operator {
             final String srcBandName = srcBand.getName();
             if (!srcBandName.contains(OilSpillDetectionOp.OILSPILLMASK_NAME)) {
 
-                final Band targetBand = ProductUtils.copyBand(srcBandName, sourceProduct, targetProduct, false);
-                targetBand.setSourceImage(srcBand.getSourceImage());
+                final Band targetBand = ProductUtils.copyBand(srcBandName, sourceProduct, targetProduct, true);
 
             } else {
                 ProductUtils.copyBand(srcBandName, sourceProduct, targetProduct, false);

--- a/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/oceantools/OilSpillDetectionOp.java
+++ b/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/oceantools/OilSpillDetectionOp.java
@@ -200,8 +200,7 @@ public class OilSpillDetectionOp extends Operator {
             final String targetBandName = srcBandNames + OILSPILLMASK_NAME;
             targetBandNameToSourceBandName.put(targetBandName, srcBandNames);
 
-            final Band targetBand = ProductUtils.copyBand(srcBand.getName(), sourceProduct, targetProduct, false);
-            targetBand.setSourceImage(srcBand.getSourceImage());
+            final Band targetBand = ProductUtils.copyBand(srcBand.getName(), sourceProduct, targetProduct, true);
 
             final Band targetBandMask = new Band(targetBandName,
                     ProductData.TYPE_INT8,

--- a/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/oceantools/OilSpillDetectionOp.java
+++ b/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/oceantools/OilSpillDetectionOp.java
@@ -245,7 +245,7 @@ public class OilSpillDetectionOp extends Operator {
             final Band sourceBand = sourceProduct.getBand(srcBandName);
             final Tile sourceTile = getSourceTile(sourceBand, sourceTileRectangle);
             final ProductData srcBuffer = sourceTile.getDataBuffer();
-            final double noDataValue = sourceBand.getNoDataValue();
+            final Double noDataValue = sourceBand.getNoDataValue();
 
             final TileIndex trgIndex = new TileIndex(targetTile);
             final TileIndex srcIndex = new TileIndex(sourceTile);    // src and trg tile are different size
@@ -257,7 +257,7 @@ public class OilSpillDetectionOp extends Operator {
                 srcIndex.calculateStride(ty);
                 for (int tx = tx0; tx < maxx; tx++) {
                     final double v = srcBuffer.getElemDoubleAt(srcIndex.getIndex(tx));
-                    if (v == noDataValue) {
+                    if (noDataValue.equals(v)) {
                         trgData.setElemIntAt(trgIndex.getIndex(tx), 0);
                         continue;
                     }

--- a/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/oceantools/WindFieldEstimationOp.java
+++ b/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/oceantools/WindFieldEstimationOp.java
@@ -248,6 +248,8 @@ public class WindFieldEstimationOp extends Operator {
                     sourceImageWidth,
                     sourceImageHeight);
 
+            targetBand.setNoDataValueUsed(true);
+            targetBand.setNoDataValue(srcBand.getNoDataValue());
             targetBand.setUnit(unit);
             targetProduct.addBand(targetBand);
             bandWindFieldRecord.put(srcBandName, new ArrayList<>());

--- a/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/oceantools/WindFieldEstimationOp.java
+++ b/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/oceantools/WindFieldEstimationOp.java
@@ -391,7 +391,7 @@ public class WindFieldEstimationOp extends Operator {
      * @param noDataValue The NoDataValue for the source band.
      * @return The number of land pixels.
      */
-    private int getNumLandPixels(final Tile sourceTile, final double noDataValue) {
+    private int getNumLandPixels(final Tile sourceTile, final Double noDataValue) {
 
         final Rectangle sourceTileRectangle = sourceTile.getRectangle();
         final int x0 = sourceTileRectangle.x;
@@ -407,7 +407,7 @@ public class WindFieldEstimationOp extends Operator {
         int numberOfLandPixels = 0;
         for (int y = y0; y < maxY; y++) {
             for (int x = x0; x < maxX; x++) {
-                if (sourceTile.getDataBuffer().getElemDoubleAt(sourceTile.getDataBufferIndex(x, y)) == noDataValue) {
+                if (noDataValue.equals(sourceTile.getDataBuffer().getElemDoubleAt(sourceTile.getDataBufferIndex(x, y)))) {
                     numberOfLandPixels++;
                 }
             }
@@ -500,7 +500,7 @@ public class WindFieldEstimationOp extends Operator {
     }
 
     private void getImagette(final Tile sourceTile, final int numLandPixels,
-                             final double noDataValue, final double[][] imagette) {
+                             final Double noDataValue, final double[][] imagette) {
 
         final Rectangle sourceTileRectangle = sourceTile.getRectangle();
         final int x0 = sourceTileRectangle.x;
@@ -519,7 +519,7 @@ public class WindFieldEstimationOp extends Operator {
             for (int y = y0; y < maxY; y++) {
                 for (int x = x0; x < maxX; x++) {
                     final double v = sourceTile.getDataBuffer().getElemDoubleAt(sourceTile.getDataBufferIndex(x, y));
-                    if (v != noDataValue) {
+                    if (!noDataValue.equals(v)) {
                         mean += v;
                     }
                 }
@@ -529,7 +529,7 @@ public class WindFieldEstimationOp extends Operator {
             for (int y = y0; y < maxY; y++) {
                 for (int x = x0; x < maxX; x++) {
                     final double v = sourceTile.getDataBuffer().getElemDoubleAt(sourceTile.getDataBufferIndex(x, y));
-                    if (v == noDataValue) {
+                    if (noDataValue.equals(v)) {
                         imagette[y - y0][x - x0] = mean;
                     } else {
                         imagette[y - y0][x - x0] = v;

--- a/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/urban/SpeckleDivergenceOp.java
+++ b/s1tbx-op-feature-extraction/src/main/java/org/esa/s1tbx/fex/gpf/urban/SpeckleDivergenceOp.java
@@ -250,7 +250,7 @@ public class SpeckleDivergenceOp extends Operator {
             final Band sourceBand = sourceProduct.getBand(srcBandName);
             final Tile sourceTile = getSourceTile(sourceBand, sourceTileRectangle);
             final ProductData srcData = sourceTile.getDataBuffer();
-            final double noDataValue = sourceBand.getNoDataValue();
+            final Double noDataValue = sourceBand.getNoDataValue();
             final Unit.UnitType bandUnit = Unit.getUnitType(sourceBand);
 
             final Band maskBand = sourceProduct.getBand(TerrainMaskOp.TERRAIN_MASK_NAME);
@@ -275,8 +275,8 @@ public class SpeckleDivergenceOp extends Operator {
                     final int idx = trgIndex.getIndex(tx);
 
                     final double v = srcData.getElemDoubleAt(srcIndex.getIndex(tx));
-                    if (v == noDataValue || (maskBand != null && maskData.getElemIntAt(idx) == 1)) {
-                        trgData.setElemFloatAt(idx, (float) noDataValue);
+                    if (noDataValue.equals(v) || (maskBand != null && maskData.getElemIntAt(idx) == 1)) {
+                        trgData.setElemFloatAt(idx, noDataValue.floatValue());
                         continue;
                     }
 

--- a/s1tbx-op-insar-ui/pom.xml
+++ b/s1tbx-op-insar-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-insar-ui</artifactId>

--- a/s1tbx-op-insar-ui/pom.xml
+++ b/s1tbx-op-insar-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-insar-ui</artifactId>

--- a/s1tbx-op-insar-ui/pom.xml
+++ b/s1tbx-op-insar-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <artifactId>s1tbx-op-insar-ui</artifactId>

--- a/s1tbx-op-insar-ui/pom.xml
+++ b/s1tbx-op-insar-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-insar-ui</artifactId>

--- a/s1tbx-op-insar-ui/pom.xml
+++ b/s1tbx-op-insar-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <artifactId>s1tbx-op-insar-ui</artifactId>

--- a/s1tbx-op-insar-ui/pom.xml
+++ b/s1tbx-op-insar-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-insar-ui</artifactId>

--- a/s1tbx-op-insar-ui/pom.xml
+++ b/s1tbx-op-insar-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <artifactId>s1tbx-op-insar-ui</artifactId>

--- a/s1tbx-op-insar-ui/src/main/java/org/esa/s1tbx/insar/gpf/ui/OffsetTrackingOpUI.java
+++ b/s1tbx-op-insar-ui/src/main/java/org/esa/s1tbx/insar/gpf/ui/OffsetTrackingOpUI.java
@@ -59,13 +59,15 @@ public class OffsetTrackingOpUI extends BaseOperatorUI {
     private final JTextField maxVelocity = new JTextField("");
     private final JTextField radius = new JTextField("");
 
-    // Other option
+    // Other options
     private final JComboBox resamplingType = new JComboBox(ResamplingFactory.resamplingNames);
-    final JCheckBox turnOffSpacialAverageCheckBox = new JCheckBox("Turn Off Spacial Average");
-    final JCheckBox turnOffFillHoleCheckBox = new JCheckBox("Turn Off Fill Hole");
+    final JCheckBox spacialAverageCheckBox = new JCheckBox("Spacial Average");
+    final JCheckBox fillHoleCheckBox = new JCheckBox("Fill Holes");
 
-    private Boolean turnOffSpacialAverage = false;
-    private Boolean turnOffFillHole = false;
+    private Boolean spacialAverage = true;
+    private Boolean fillHoles = true;
+
+    private final JComboBox vectorsCombo = new JComboBox();
 
     @Override
     public JComponent CreateOpTab(String operatorName, Map<String, Object> parameterMap, AppContext appContext) {
@@ -74,15 +76,15 @@ public class OffsetTrackingOpUI extends BaseOperatorUI {
         final JComponent panel = createPanel();
         initParameters();
 
-        turnOffSpacialAverageCheckBox.addItemListener(new ItemListener() {
+        spacialAverageCheckBox.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
-                turnOffSpacialAverage = (e.getStateChange() == ItemEvent.SELECTED);
+                spacialAverage = (e.getStateChange() == ItemEvent.SELECTED);
             }
         });
 
-        turnOffFillHoleCheckBox.addItemListener(new ItemListener() {
+        fillHoleCheckBox.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
-                turnOffFillHole = (e.getStateChange() == ItemEvent.SELECTED);
+                fillHoles = (e.getStateChange() == ItemEvent.SELECTED);
             }
         });
 
@@ -120,14 +122,24 @@ public class OffsetTrackingOpUI extends BaseOperatorUI {
             setDerivedRangeParameters();
         }
 
-        turnOffSpacialAverage = (Boolean)paramMap.get("turnOffSpacialAverage");
-        if(turnOffSpacialAverage != null) {
-            turnOffSpacialAverageCheckBox.setSelected(turnOffSpacialAverage);
+        spacialAverage = (Boolean)paramMap.get("turnOffSpacialAverage");
+        if(spacialAverage != null) {
+            spacialAverageCheckBox.setSelected(spacialAverage);
         }
 
-        turnOffFillHole = (Boolean)paramMap.get("turnOffFillHole");
-        if(turnOffFillHole != null) {
-            turnOffFillHoleCheckBox.setSelected(turnOffFillHole);
+        fillHoles = (Boolean)paramMap.get("turnOffFillHole");
+        if(fillHoles != null) {
+            fillHoleCheckBox.setSelected(fillHoles);
+        }
+
+        vectorsCombo.removeAllItems();
+        final String[] geometryNames = getGeometries();
+        for (String g : geometryNames) {
+            vectorsCombo.addItem(g);
+        }
+        final String selectedGeometry = (String) paramMap.get("roiVector");
+        if (selectedGeometry != null) {
+            vectorsCombo.setSelectedItem(selectedGeometry);
         }
     }
 
@@ -155,8 +167,10 @@ public class OffsetTrackingOpUI extends BaseOperatorUI {
         setDerivedAzimuthParameters();
         setDerivedRangeParameters();
 
-        paramMap.put("turnOffSpacialAverage", turnOffSpacialAverage);
-        paramMap.put("turnOffFillHole", turnOffFillHole);
+        paramMap.put("spacialAverage", spacialAverage);
+        paramMap.put("fillHoles", fillHoles);
+
+        paramMap.put("roiVector", vectorsCombo.getSelectedItem());
     }
 
     private JComponent createPanel() {
@@ -172,6 +186,7 @@ public class OffsetTrackingOpUI extends BaseOperatorUI {
         final GridBagConstraints gbc2 = DialogUtils.createGridBagConstraints();
         gridPanel.setBorder(BorderFactory.createTitledBorder("Output Grid"));
 
+        gridAzimuthSpacing.setColumns(3);
         DialogUtils.addComponent(gridPanel, gbc2, "Grid Azimuth Spacing (in pixels):", gridAzimuthSpacing);
         gbc2.gridy++;
         DialogUtils.addComponent(gridPanel, gbc2, "Grid Range Spacing (in pixels):", gridRangeSpacing);
@@ -214,9 +229,14 @@ public class OffsetTrackingOpUI extends BaseOperatorUI {
 
         DialogUtils.addComponent(contentPane, gbc, "Resampling Type:", resamplingType);
         gbc.gridy++;
-        contentPane.add(turnOffSpacialAverageCheckBox, gbc);
+        gbc.gridx = 1;
+        contentPane.add(spacialAverageCheckBox, gbc);
         gbc.gridy++;
-        contentPane.add(turnOffFillHoleCheckBox, gbc);
+        contentPane.add(fillHoleCheckBox, gbc);
+        gbc.gridx = 0;
+        gbc.gridy++;
+
+        DialogUtils.addComponent(contentPane, gbc, "ROI Vector Mask:", vectorsCombo);
         gbc.gridy++;
 
         DialogUtils.fillPanel(contentPane, gbc);

--- a/s1tbx-op-insar-ui/src/main/java/org/esa/s1tbx/insar/gpf/ui/OffsetTrackingOpUI.java
+++ b/s1tbx-op-insar-ui/src/main/java/org/esa/s1tbx/insar/gpf/ui/OffsetTrackingOpUI.java
@@ -61,10 +61,10 @@ public class OffsetTrackingOpUI extends BaseOperatorUI {
 
     // Other options
     private final JComboBox resamplingType = new JComboBox(ResamplingFactory.resamplingNames);
-    final JCheckBox spacialAverageCheckBox = new JCheckBox("Spacial Average");
+    final JCheckBox spatialAverageCheckBox = new JCheckBox("Spatial Average");
     final JCheckBox fillHoleCheckBox = new JCheckBox("Fill Holes");
 
-    private Boolean spacialAverage = true;
+    private Boolean spatialAverage = true;
     private Boolean fillHoles = true;
 
     private final JComboBox vectorsCombo = new JComboBox();
@@ -76,9 +76,9 @@ public class OffsetTrackingOpUI extends BaseOperatorUI {
         final JComponent panel = createPanel();
         initParameters();
 
-        spacialAverageCheckBox.addItemListener(new ItemListener() {
+        spatialAverageCheckBox.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
-                spacialAverage = (e.getStateChange() == ItemEvent.SELECTED);
+                spatialAverage = (e.getStateChange() == ItemEvent.SELECTED);
             }
         });
 
@@ -122,9 +122,9 @@ public class OffsetTrackingOpUI extends BaseOperatorUI {
             setDerivedRangeParameters();
         }
 
-        spacialAverage = (Boolean)paramMap.get("turnOffSpacialAverage");
-        if(spacialAverage != null) {
-            spacialAverageCheckBox.setSelected(spacialAverage);
+        spatialAverage = (Boolean)paramMap.get("spatialAverage");
+        if(spatialAverage != null) {
+            spatialAverageCheckBox.setSelected(spatialAverage);
         }
 
         fillHoles = (Boolean)paramMap.get("turnOffFillHole");
@@ -167,7 +167,7 @@ public class OffsetTrackingOpUI extends BaseOperatorUI {
         setDerivedAzimuthParameters();
         setDerivedRangeParameters();
 
-        paramMap.put("spacialAverage", spacialAverage);
+        paramMap.put("spatialAverage", spatialAverage);
         paramMap.put("fillHoles", fillHoles);
 
         paramMap.put("roiVector", vectorsCombo.getSelectedItem());
@@ -230,7 +230,7 @@ public class OffsetTrackingOpUI extends BaseOperatorUI {
         DialogUtils.addComponent(contentPane, gbc, "Resampling Type:", resamplingType);
         gbc.gridy++;
         gbc.gridx = 1;
-        contentPane.add(spacialAverageCheckBox, gbc);
+        contentPane.add(spatialAverageCheckBox, gbc);
         gbc.gridy++;
         contentPane.add(fillHoleCheckBox, gbc);
         gbc.gridx = 0;

--- a/s1tbx-op-insar-ui/src/main/java/org/esa/s1tbx/insar/gpf/ui/OffsetTrackingOpUI.java
+++ b/s1tbx-op-insar-ui/src/main/java/org/esa/s1tbx/insar/gpf/ui/OffsetTrackingOpUI.java
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see http://www.gnu.org/licenses/
  */
-package org.esa.s1tbx.insar.gpf.ui.coregistration;
+package org.esa.s1tbx.insar.gpf.ui;
 
 import org.esa.snap.core.datamodel.MetadataElement;
 import org.esa.snap.core.dataop.resamp.ResamplingFactory;

--- a/s1tbx-op-insar-ui/src/main/java/org/esa/s1tbx/insar/gpf/ui/coregistration/OffsetTrackingOpUI.java
+++ b/s1tbx-op-insar-ui/src/main/java/org/esa/s1tbx/insar/gpf/ui/coregistration/OffsetTrackingOpUI.java
@@ -61,7 +61,11 @@ public class OffsetTrackingOpUI extends BaseOperatorUI {
 
     // Other option
     private final JComboBox resamplingType = new JComboBox(ResamplingFactory.resamplingNames);
+    final JCheckBox turnOffSpacialAverageCheckBox = new JCheckBox("Turn Off Spacial Average");
+    final JCheckBox turnOffFillHoleCheckBox = new JCheckBox("Turn Off Fill Hole");
 
+    private Boolean turnOffSpacialAverage = false;
+    private Boolean turnOffFillHole = false;
 
     @Override
     public JComponent CreateOpTab(String operatorName, Map<String, Object> parameterMap, AppContext appContext) {
@@ -69,6 +73,18 @@ public class OffsetTrackingOpUI extends BaseOperatorUI {
         initializeOperatorUI(operatorName, parameterMap);
         final JComponent panel = createPanel();
         initParameters();
+
+        turnOffSpacialAverageCheckBox.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                turnOffSpacialAverage = (e.getStateChange() == ItemEvent.SELECTED);
+            }
+        });
+
+        turnOffFillHoleCheckBox.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                turnOffFillHole = (e.getStateChange() == ItemEvent.SELECTED);
+            }
+        });
 
         return new JScrollPane(panel);
     }
@@ -103,6 +119,16 @@ public class OffsetTrackingOpUI extends BaseOperatorUI {
             setDerivedAzimuthParameters();
             setDerivedRangeParameters();
         }
+
+        turnOffSpacialAverage = (Boolean)paramMap.get("turnOffSpacialAverage");
+        if(turnOffSpacialAverage != null) {
+            turnOffSpacialAverageCheckBox.setSelected(turnOffSpacialAverage);
+        }
+
+        turnOffFillHole = (Boolean)paramMap.get("turnOffFillHole");
+        if(turnOffFillHole != null) {
+            turnOffFillHoleCheckBox.setSelected(turnOffFillHole);
+        }
     }
 
     @Override
@@ -128,6 +154,9 @@ public class OffsetTrackingOpUI extends BaseOperatorUI {
 
         setDerivedAzimuthParameters();
         setDerivedRangeParameters();
+
+        paramMap.put("turnOffSpacialAverage", turnOffSpacialAverage);
+        paramMap.put("turnOffFillHole", turnOffFillHole);
     }
 
     private JComponent createPanel() {
@@ -184,6 +213,10 @@ public class OffsetTrackingOpUI extends BaseOperatorUI {
         gbc.gridy++;
 
         DialogUtils.addComponent(contentPane, gbc, "Resampling Type:", resamplingType);
+        gbc.gridy++;
+        contentPane.add(turnOffSpacialAverageCheckBox, gbc);
+        gbc.gridy++;
+        contentPane.add(turnOffFillHoleCheckBox, gbc);
         gbc.gridy++;
 
         DialogUtils.fillPanel(contentPane, gbc);

--- a/s1tbx-op-insar-ui/src/main/resources/org/esa/s1tbx/insar/docs/operators/DEMAssistedCoregistrationOp.html
+++ b/s1tbx-op-insar-ui/src/main/resources/org/esa/s1tbx/insar/docs/operators/DEMAssistedCoregistrationOp.html
@@ -20,7 +20,7 @@
 
 <h3>DEM-Assisted Coregistration (Back Geocoding)</h3>
 
-<p class="MsoNormal"><span>This opaerator co-registers two two or more products using the
+<p class="MsoNormal"><span>This operator co-registers two two or more products using the
 orbits of the products and a Digital Elevation Model
 (DEM).<br>
 </span></p>

--- a/s1tbx-op-insar-ui/src/main/resources/org/esa/s1tbx/insar/docs/operators/OffsetTrackingOp.html
+++ b/s1tbx-op-insar-ui/src/main/resources/org/esa/s1tbx/insar/docs/operators/OffsetTrackingOp.html
@@ -1,6 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html><head><title>Help - Cross Correlation Operator</title>
 
+
   
 
   
@@ -19,20 +20,71 @@
 
 <h3>Offset Tracking Operator</h3>
 <div style="text-align: left;">The Offset Tracking operator estimates
-the movement of glacier surfaces between two SAR images in both
+the movement of glacier surfaces between two SAR images (master and slave) in both
 slant-range and azimuth direction. It performs cross-correlation on
 selected GCP-patches in master and slave images, and computes glacier
 velocities based on the shift computed for each GCP. Finally the
 glacier velocity map is computed through interpolation of the
 velocities computed for the GCP grid.<br>
 </div>
+<h4>Brief Implementation Details</h4>
+
+
+<p>The offset tracking is performed by the following sub-steps:<br>
+
+</p>
+
+
+<ol>
+  <li>For user specified GCP grid in master image, compute corresponding slave pixel positions using normalized cross-correlation.</li>
+  <li>For each point on the GCP grid, compute offset between master and
+slave images, and movement velocity. Point with velocity exceeding the
+user specified maximum velocity will be marked as outlier.<br>
+  </li>
+  <li>Perform local average for offset on valid GCP points. <br>
+  </li>
+  <li>Fill holes caused by the outliers. Offset and velocity will be calculated using weighted average. <br>
+  </li>
+  <li>Finally, compute the velocity for all pixels in the master image from the velocity on GCP grid by interpolation.<br>
+  </li>
+</ol>
+<h4>Offset Tracking with SNAP</h4>
+
+
+<p>The master and slave images used in offset tracking should be
+coregistered first by DEM assisted coregistration. The following steps
+should be followed: <br>
+</p>
+<ol>
+  <li>Run Apply Orbit File operator respectively with master and slave
+images as input to update the orbit state vectors in the metadata of
+the product with the precise orbit file. <br>
+  </li>
+  <li>Run DEM Assisted Coregistration operator with both master and
+slave output from step 1 as input to coregister master and slave images.</li>
+  <li>Run Offset Tracking operator with the coregistered stack as input to produce the glacier velocity map. <br>
+  </li>
+  <li>To display the glacier velocity map, double click on the velocity
+band name. To show the glacier velocity vectors, click on "Layer
+Manager" and add "Coregistered GCP Movement Vector" layer. The velocity
+vectors on the user specified GCP grid will be displayed.<br>
+  </li>
+</ol>
+
+
 <h4>Parameters Used</h4>
 
 &nbsp;&nbsp;&nbsp;The parameters used by the operator are as follows:
 <ol>
 
-  <li>Grid Azimuth Spacing: The GCP grid azimuth spacing in pixels.</li>
-  <li>Grid Range Spacing: The GCP grid range spacing in pixels. </li>
+  <li>Grid Azimuth Spacing (in pixels): The GCP grid azimuth spacing in pixels.</li>
+  <li>Grid Range Spacing (in pixels): The GCP grid range spacing in pixels.</li>
+  <li>Grid Azimuth Spacing (in meters): The GCP grid azimuth spacing in meters. It is updated automatically based on user input in 1.</li>
+  <li>Grid Range Spacing (in meters): The GCP grid range spacing in meters. It is updated automatically based on user input in 2.</li>
+  <li>Grid Azimuth Dimension: The number of lines of the GCP grid. It is updated automatically based on user input in 1.</li>
+  <li>Grid Range Dimension: The number of columns of the GCP grid. It is updated automatically based on user input in 2.</li>
+  <li>Total GCP Points: The total number of points in the GCP grid. It is updated automatically based on user input in 1 and 2.</li>
+
   
   <li>Registration Window Width: The window width for
 cross-correlation. </li>
@@ -43,8 +95,8 @@ for normalized cross-correlation value. If the cross-correlation value
 is greater than the threshold, then the estimated offset is
 considered valid, otherwise invalid. <br>
 </li>
-  <li>Average Box Size: Size of sliding window for averaging offsets computed for GCPs. </li>
-  <li>Max Velocity: The maximum allowed glacier velocity in meters per day. It is used in eliminating outliers.<br>
+  <li>&nbsp;Average Box Size: Size of sliding window for averaging offsets computed for GCPs. </li>
+  <li>&nbsp;Max Velocity: The maximum allowed glacier velocity in meters per day. It is used in eliminating outliers.<br>
 </li>
   <li>Radius for Hole Filling: It defines the size of the window
 for hole filling. For GCP that has no valid offset, a window with given

--- a/s1tbx-op-insar-ui/src/main/resources/org/esa/s1tbx/insar/layer.xml
+++ b/s1tbx-op-insar-ui/src/main/resources/org/esa/s1tbx/insar/layer.xml
@@ -250,8 +250,8 @@
             <attr name="operatorUIClass" stringvalue="org.esa.s1tbx.insar.gpf.ui.IntegerInterferogramOpUI"/>
             <attr name="operatorName" stringvalue="IntegerInterferogram"/>
         </file>
-        <file name="org.esa.s1tbx.insar.gpf.ui.coregistration.OffsetTrackingOpUI">
-            <attr name="operatorUIClass" stringvalue="org.esa.s1tbx.insar.gpf.ui.coregistration.OffsetTrackingOpUI"/>
+        <file name="org.esa.s1tbx.insar.gpf.ui.OffsetTrackingOpUI">
+            <attr name="operatorUIClass" stringvalue="org.esa.s1tbx.insar.gpf.ui.OffsetTrackingOpUI"/>
             <attr name="operatorName" stringvalue="Offset-Tracking"/>
         </file>
     </folder>

--- a/s1tbx-op-insar/pom.xml
+++ b/s1tbx-op-insar/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-insar</artifactId>

--- a/s1tbx-op-insar/pom.xml
+++ b/s1tbx-op-insar/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-insar</artifactId>

--- a/s1tbx-op-insar/pom.xml
+++ b/s1tbx-op-insar/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <artifactId>s1tbx-op-insar</artifactId>

--- a/s1tbx-op-insar/pom.xml
+++ b/s1tbx-op-insar/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <artifactId>s1tbx-op-insar</artifactId>

--- a/s1tbx-op-insar/pom.xml
+++ b/s1tbx-op-insar/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-insar</artifactId>

--- a/s1tbx-op-insar/pom.xml
+++ b/s1tbx-op-insar/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <artifactId>s1tbx-op-insar</artifactId>

--- a/s1tbx-op-insar/pom.xml
+++ b/s1tbx-op-insar/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-insar</artifactId>

--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/CoherenceOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/CoherenceOp.java
@@ -332,6 +332,8 @@ public class CoherenceOp extends Operator {
 
                 final String coherenceBandName = productTag + tag;
                 final Band coherenceBand = targetProduct.addBand(coherenceBandName, ProductData.TYPE_FLOAT32);
+                coherenceBand.setNoDataValueUsed(true);
+                coherenceBand.setNoDataValue(master.realBand.getNoDataValue());
                 container.addBand(Unit.COHERENCE, coherenceBand.getName());
                 coherenceBand.setUnit(Unit.COHERENCE);
                 targetBandNames.add(coherenceBand.getName());

--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/InterferogramOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/InterferogramOp.java
@@ -449,10 +449,12 @@ public class InterferogramOp extends Operator {
 
             if (includeCoherence) {
                 final String targetBandCoh = "coh" + tag;
-                final Band cohBand = targetProduct.addBand(targetBandCoh, ProductData.TYPE_FLOAT32);
-                container.addBand(Unit.COHERENCE, cohBand.getName());
-                cohBand.setUnit(Unit.COHERENCE);
-                targetBandNames.add(cohBand.getName());
+                final Band coherenceBand = targetProduct.addBand(targetBandCoh, ProductData.TYPE_FLOAT32);
+                coherenceBand.setNoDataValueUsed(true);
+                coherenceBand.setNoDataValue(master.realBand.getNoDataValue());
+                container.addBand(Unit.COHERENCE, coherenceBand.getName());
+                coherenceBand.setUnit(Unit.COHERENCE);
+                targetBandNames.add(coherenceBand.getName());
             }
 
             if (subtractFlatEarthPhase && OUTPUT_FLAT_EARTH_PHASE) {

--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/OffsetTrackingOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/OffsetTrackingOp.java
@@ -125,8 +125,8 @@ public class OffsetTrackingOp extends Operator {
             description = "Methods for velocity interpolation.", label = "Resampling Type")
     private String resamplingType = ResamplingFactory.BICUBIC_INTERPOLATION_NAME;
 
-    @Parameter(defaultValue = "true", label = "Spacial Average")
-    private boolean spacialAverage = true;
+    @Parameter(defaultValue = "true", label = "Spatial Average")
+    private boolean spatialAverage = true;
 
     @Parameter(defaultValue = "true", label = "Fill Holes")
     private boolean fillHoles = true;
@@ -482,7 +482,7 @@ public class OffsetTrackingOp extends Operator {
 
         computeGCPOffsets();
 
-        if (spacialAverage) {
+        if (spatialAverage) {
             averageOffsets();
         }
 

--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/OffsetTrackingOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/OffsetTrackingOp.java
@@ -62,7 +62,7 @@ import java.util.Map;
  */
 
 @OperatorMetadata(alias = "Offset-Tracking",
-        category = "Radar/Feature Extraction",
+        category = "Radar/SAR Applications",
         authors = "Jun Lu, Luis Veci",
         version = "1.0",
         copyright = "Copyright (C) 2016 by Array Systems Computing Inc.",

--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/OffsetTrackingOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/OffsetTrackingOp.java
@@ -13,9 +13,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see http://www.gnu.org/licenses/
  */
-package org.esa.s1tbx.insar.gpf.coregistration;
+package org.esa.s1tbx.insar.gpf;
 
 import com.bc.ceres.core.ProgressMonitor;
+import org.esa.s1tbx.insar.gpf.coregistration.CrossCorrelationOp;
 import org.esa.snap.core.datamodel.*;
 import org.esa.snap.core.dataop.downloadable.StatusProgressMonitor;
 import org.esa.snap.core.dataop.resamp.Resampling;
@@ -33,7 +34,6 @@ import org.esa.snap.core.util.SystemUtils;
 import org.esa.snap.engine_utilities.datamodel.AbstractMetadata;
 import org.esa.snap.engine_utilities.datamodel.Unit;
 import org.esa.snap.engine_utilities.gpf.*;
-import org.esa.snap.engine_utilities.util.Maths;
 import org.jblas.ComplexDouble;
 import org.jblas.ComplexDoubleMatrix;
 import org.jlinda.core.coregistration.utils.CoregistrationUtils;

--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/PhaseToDisplacementOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/PhaseToDisplacementOp.java
@@ -179,7 +179,7 @@ public final class PhaseToDisplacementOp extends Operator {
                 for (int x = x0; x < x0 + w; x++) {
 
                     final double phase = sourceData.getElemDoubleAt(srcIndex.getIndex(x));
-                    final double displacement = wavelengthOver4PI*phase;
+                    final double displacement = -wavelengthOver4PI*phase;
                     targetData.setElemDoubleAt(trgIndex.getIndex(x), displacement);
                 }
             }

--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/PhaseToElevationOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/PhaseToElevationOp.java
@@ -392,8 +392,8 @@ public final class PhaseToElevationOp extends Operator {
             final int y = r * seedGridResY + slopeCalRadius;
             for (int c = 0; c < seedGridSize; c++) {
                 final int x = c * seedGridResX + slopeCalRadius;
-                final double h = getElevation(x, y);
-                if (h != demNoDataValue && h > 0.0) {
+                final Double h = getElevation(x, y);
+                if (!h.equals(demNoDataValue) && h > 0.0) {
                     SeedRecord seed = new SeedRecord(x, y, h, computeSlope(x, y, slopeCalRadius));
                     seedList.add(seed);
                 }
@@ -518,14 +518,14 @@ public final class PhaseToElevationOp extends Operator {
     private double computeSlope(final int xc, final int yc, final int slopeCalRadius) throws Exception {
 
         double slope = 0.0;
-        double h = 0.0;
+        Double h = 0.0;
         int numPoints = 0;
         final double hc = getElevation(xc, yc);
         final int halfSlopeCalRadius = slopeCalRadius / 2;
         for (int y = yc - slopeCalRadius; y <= yc + slopeCalRadius; y += slopeCalRadius) {
             for (int x = xc - slopeCalRadius; x <= xc + slopeCalRadius; x += halfSlopeCalRadius) {
                 h = getElevation(x, y);
-                if (h != demNoDataValue) {
+                if (!h.equals(demNoDataValue)) {
                     slope += Math.abs(h - hc);
                     numPoints++;
                 }
@@ -534,13 +534,13 @@ public final class PhaseToElevationOp extends Operator {
         return slope / numPoints;
     }
 
-    public static class SeedRecord implements Comparable<SeedRecord> {
+    static class SeedRecord implements Comparable<SeedRecord> {
         public int x;
         public int y;
         public double height;
         public double slope;
 
-        public SeedRecord(final int x, final int y, final double h, final double slope) {
+        SeedRecord(final int x, final int y, final double h, final double slope) {
             this.x = x;
             this.y = y;
             this.height = h;

--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/CrossCorrelationOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/CrossCorrelationOp.java
@@ -1018,10 +1018,10 @@ public class CrossCorrelationOp extends Operator {
         try {
             final Tile masterImagetteRaster1 = getSourceTile(masterBand1, masterImagetteRectangle);
             final ProductData masterData1 = masterImagetteRaster1.getDataBuffer();
-            final double noDataValue1 = masterBand1.getNoDataValue();
+            final Double noDataValue1 = masterBand1.getNoDataValue();
 
             ProductData masterData2 = null;
-            double noDataValue2 = 0.0;
+            Double noDataValue2 = 0.0;
             if (complexCoregistration) {
                 final Tile masterImagetteRaster2 = getSourceTile(masterBand2, masterImagetteRectangle);
                 masterData2 = masterImagetteRaster2.getDataBuffer();
@@ -1039,13 +1039,13 @@ public class CrossCorrelationOp extends Operator {
                     if (complexCoregistration) {
                         final double v1 = masterData1.getElemDoubleAt(index);
                         final double v2 = masterData2.getElemDoubleAt(index);
-                        if (v1 == noDataValue1 && v2 == noDataValue2) {
+                        if (noDataValue1.equals(v1) && noDataValue2.equals(v2)) {
                             numInvalidPixels++;
                         }
                         mI[k++] = v1 * v1 + v2 * v2;
                     } else {
                         final double v = masterData1.getElemDoubleAt(index);
-                        if (v == noDataValue1) {
+                        if (noDataValue1.equals(v)) {
                             numInvalidPixels++;
                         }
                         mI[k++] = v;
@@ -1079,11 +1079,11 @@ public class CrossCorrelationOp extends Operator {
         try {
             final Tile slaveImagetteRaster1 = getSourceTile(slaveBand1, slaveImagetteRectangle);
             final ProductData slaveData1 = slaveImagetteRaster1.getDataBuffer();
-            final double noDataValue1 = slaveBand1.getNoDataValue();
+            final Double noDataValue1 = slaveBand1.getNoDataValue();
 
             Tile slaveImagetteRaster2 = null;
             ProductData slaveData2 = null;
-            double noDataValue2 = 0.0;
+            Double noDataValue2 = 0.0;
             if (complexCoregistration) {
                 slaveImagetteRaster2 = getSourceTile(slaveBand2, slaveImagetteRectangle);
                 slaveData2 = slaveImagetteRaster2.getDataBuffer();
@@ -1124,7 +1124,7 @@ public class CrossCorrelationOp extends Operator {
                                                                   slaveData2.getElemDoubleAt(x10),
                                                                   slaveData2.getElemDoubleAt(x11));
 
-                        if (v1 == noDataValue1 && v2 == noDataValue2) {
+                        if (noDataValue1.equals(v1) && noDataValue2.equals(v2)) {
                             numInvalidPixels++;
                         }
                         sI[k] = v1 * v1 + v2 * v2;
@@ -1135,7 +1135,7 @@ public class CrossCorrelationOp extends Operator {
                                                                  slaveData1.getElemDoubleAt(x10),
                                                                  slaveData1.getElemDoubleAt(x11));
 
-                        if (v == noDataValue1) {
+                        if (noDataValue1.equals(v)) {
                             numInvalidPixels++;
                         }
                         sI[k] = v;

--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/CrossCorrelationOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/CrossCorrelationOp.java
@@ -17,6 +17,7 @@ package org.esa.s1tbx.insar.gpf.coregistration;
 
 import com.bc.ceres.core.ProgressMonitor;
 import org.apache.commons.math3.util.FastMath;
+import org.esa.s1tbx.insar.gpf.support.JAIFunctions;
 import org.esa.snap.core.datamodel.Band;
 import org.esa.snap.core.datamodel.GcpDescriptor;
 import org.esa.snap.core.datamodel.GeoCoding;

--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/DEMAssistedCoregistrationOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/DEMAssistedCoregistrationOp.java
@@ -516,10 +516,10 @@ public final class DEMAssistedCoregistrationOp extends Operator {
                     GeoPos gp = dem.getGeoPos(pix);
                     lat[l][p] = gp.lat;
                     lon[l][p] = gp.lon;
-                    double alt = dem.getElevation(gp);
+                    Double alt = dem.getElevation(gp);
 
-                    if (alt == demNoDataValue) { // get corrected elevation for 0
-                        alt = egm.getEGM(gp.lat, gp.lon);
+                    if (alt.equals(demNoDataValue)) { // get corrected elevation for 0
+                        alt = (double)egm.getEGM(gp.lat, gp.lon);
                     }
 
                     GeoUtils.geo2xyzWGS84(gp.lat, gp.lon, alt, posData.earthPoint);
@@ -574,7 +574,7 @@ public final class DEMAssistedCoregistrationOp extends Operator {
             boolean allElementsAreNull = true;
             final PixelPos[][] slavePixelPos = new PixelPos[h][w];
 
-            double alt = 0;
+            Double alt = 0.0;
             for(int yy = 0; yy < h; yy++) {
                 for (int xx = 0; xx < w; xx++) {
                     if (rgArray[yy][xx] == invalidIndex || azArray[yy][xx] == invalidIndex ||
@@ -584,7 +584,7 @@ public final class DEMAssistedCoregistrationOp extends Operator {
                     } else {
                         if (maskOutAreaWithoutElevation) {
                             alt = dem.getElevation(new GeoPos(latArray[yy][xx], lonArray[yy][xx]));
-                            if (alt != demNoDataValue) {
+                            if (!alt.equals(demNoDataValue)) {
                                 slavePixelPos[yy][xx] = new PixelPos(rgArray[yy][xx], azArray[yy][xx]);
                                 allElementsAreNull = false;
                             } else {

--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/WarpOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/WarpOp.java
@@ -16,6 +16,7 @@
 package org.esa.s1tbx.insar.gpf.coregistration;
 
 import com.bc.ceres.core.ProgressMonitor;
+import org.esa.s1tbx.insar.gpf.support.JAIFunctions;
 import org.esa.snap.core.datamodel.*;
 import org.esa.snap.core.dataop.dem.ElevationModel;
 import org.esa.snap.core.dataop.dem.ElevationModelDescriptor;

--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/WarpOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/coregistration/WarpOp.java
@@ -572,7 +572,7 @@ public class WarpOp extends Operator {
 
                         double height = dem.getSample(demIndexPoint.x, demIndexPoint.y);
 
-                        if (Double.isNaN(height) || height == demNoDataValue) {
+                        if (Double.isNaN(height)) {
                             height = demNoDataValue;
                         }
 

--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/support/JAIFunctions.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/support/JAIFunctions.java
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see http://www.gnu.org/licenses/
  */
-package org.esa.s1tbx.insar.gpf.coregistration;
+package org.esa.s1tbx.insar.gpf.support;
 
 import javax.media.jai.BorderExtender;
 import javax.media.jai.Interpolation;

--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/support/SARGeocoding.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/support/SARGeocoding.java
@@ -496,7 +496,7 @@ public final class SARGeocoding {
      * @param localIncidenceAngles             The local incidence angle and projected local incidence angle.
      */
     public static void computeLocalIncidenceAngle(
-            final LocalGeometry lg, final double demNoDataValue, final boolean saveLocalIncidenceAngle,
+            final LocalGeometry lg, final Double demNoDataValue, final boolean saveLocalIncidenceAngle,
             final boolean saveProjectedLocalIncidenceAngle, final boolean saveSigmaNought, final int x0,
             final int y0, final int x, final int y, final double[][] localDEM, final double[] localIncidenceAngles) {
 
@@ -509,7 +509,7 @@ public final class SARGeocoding {
         for (int i = 0; i < 3; i++) {
             final int yy = y - y0 + i;
             for (int j = 0; j < 3; j++) {
-                if (localDEM[yy][x - x0 + j] == demNoDataValue) {
+                if (demNoDataValue.equals(localDEM[yy][x - x0 + j])) {
                     return;
                 }
             }
@@ -599,7 +599,7 @@ public final class SARGeocoding {
             final int maxY = localDEM.length - 1;
             final int numN = 3;
             final GeoPos geo = new GeoPos();
-            double alt;
+            Double alt;
 
             double rightPointHeight = 0, leftPointHeight = 0, upPointHeight = 0, downPointHeight = 0;
 
@@ -611,7 +611,7 @@ public final class SARGeocoding {
                 } else {
                     alt = localDEM[yy][xx + n];
                 }
-                if (alt != demNoDataValue) {
+                if (!alt.equals(demNoDataValue)) {
                     rightPointHeight += alt;
                     ++cnt;
                 }
@@ -627,7 +627,7 @@ public final class SARGeocoding {
                 } else {
                     alt = localDEM[yy][xx - n];
                 }
-                if (alt != demNoDataValue) {
+                if (!alt.equals(demNoDataValue)) {
                     leftPointHeight += alt;
                     ++cnt;
                 }
@@ -643,7 +643,7 @@ public final class SARGeocoding {
                 } else {
                     alt = localDEM[yy - n][xx];
                 }
-                if (alt != demNoDataValue) {
+                if (!alt.equals(demNoDataValue)) {
                     upPointHeight += alt;
                     ++cnt;
                 }
@@ -659,7 +659,7 @@ public final class SARGeocoding {
                 } else {
                     alt = localDEM[yy + n][xx];
                 }
-                if (alt != demNoDataValue) {
+                if (!alt.equals(demNoDataValue)) {
                     downPointHeight += alt;
                     ++cnt;
                 }

--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/support/Sentinel1Utils.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/support/Sentinel1Utils.java
@@ -26,8 +26,10 @@ import org.esa.snap.engine_utilities.datamodel.AbstractMetadata;
 import org.esa.snap.engine_utilities.datamodel.OrbitStateVector;
 import org.esa.snap.engine_utilities.eo.Constants;
 
+import java.awt.*;
 import java.text.DateFormat;
 import java.util.*;
+import java.util.List;
 
 public final class Sentinel1Utils {
 
@@ -834,6 +836,88 @@ public final class Sentinel1Utils {
         return dcPolynomial;
     }
 
+    public double[][] computeDerampDemodPhase(
+            Sentinel1Utils.SubSwathInfo[] subSwath, final int subSwathIndex, final int sBurstIndex,
+            final Rectangle rectangle) {
+
+        final int x0 = rectangle.x;
+        final int y0 = rectangle.y;
+        final int w = rectangle.width;
+        final int h = rectangle.height;
+        final int xMax = x0 + w;
+        final int yMax = y0 + h;
+        final int s = subSwathIndex - 1;
+
+        final double[][] phase = new double[h][w];
+        final int firstLineInBurst = sBurstIndex*subSwath[s].linesPerBurst;
+        for (int y = y0; y < yMax; y++) {
+            final int yy = y - y0;
+            final double ta = (y - firstLineInBurst)*subSwath[s].azimuthTimeInterval;
+            for (int x = x0; x < xMax; x++) {
+                final int xx = x - x0;
+                final double kt = subSwath[s].dopplerRate[sBurstIndex][x];
+                final double deramp = -Constants.PI * kt * FastMath.pow(ta - subSwath[s].referenceTime[sBurstIndex][x], 2);
+                final double demod = -Constants.TWO_PI * subSwath[s].dopplerCentroid[sBurstIndex][x] * ta;
+                phase[yy][xx] = deramp + demod;
+            }
+        }
+
+        return phase;
+    }
+
+    public double[][] computeDerampPhase(
+            Sentinel1Utils.SubSwathInfo[] subSwath, final int subSwathIndex, final int burstIndex,
+            final Rectangle rectangle) {
+
+        final int x0 = rectangle.x;
+        final int y0 = rectangle.y;
+        final int w = rectangle.width;
+        final int h = rectangle.height;
+        final int xMax = x0 + w;
+        final int yMax = y0 + h;
+        final int s = subSwathIndex - 1;
+
+        final double[][] phase = new double[h][w];
+        final int firstLineInBurst = burstIndex*subSwath[s].linesPerBurst;
+        for (int y = y0; y < yMax; y++) {
+            final int yy = y - y0;
+            final double ta = (y - firstLineInBurst)*subSwath[s].azimuthTimeInterval;
+            for (int x = x0; x < xMax; x++) {
+                final int xx = x - x0;
+                final double kt = subSwath[s].dopplerRate[burstIndex][x];
+                phase[yy][xx] = -Constants.PI * kt * FastMath.pow(ta - subSwath[s].referenceTime[burstIndex][x], 2);
+            }
+        }
+
+        return phase;
+    }
+
+    public double[][] computeDemodPhase(
+            Sentinel1Utils.SubSwathInfo[] subSwath, final int subSwathIndex, final int sBurstIndex,
+            final Rectangle rectangle) {
+
+        final int x0 = rectangle.x;
+        final int y0 = rectangle.y;
+        final int w = rectangle.width;
+        final int h = rectangle.height;
+        final int xMax = x0 + w;
+        final int yMax = y0 + h;
+        final int s = subSwathIndex - 1;
+
+        final double[][] phase = new double[h][w];
+        final int firstLineInBurst = sBurstIndex*subSwath[s].linesPerBurst;
+        for (int y = y0; y < yMax; y++) {
+            final int yy = y - y0;
+            final double ta = (y - firstLineInBurst)*subSwath[s].azimuthTimeInterval;
+            for (int x = x0; x < xMax; x++) {
+                final int xx = x - x0;
+                final double kt = subSwath[s].dopplerRate[sBurstIndex][x];
+                phase[yy][xx] = -Constants.TWO_PI * subSwath[s].dopplerCentroid[sBurstIndex][x] * ta;
+            }
+        }
+
+        return phase;
+    }
 
     // =================================================================================
     private MetadataElement getCalibrationVectorList(final int subSwathIndex, final String polarization) {

--- a/s1tbx-op-insar/src/main/resources/META-INF/services/org.esa.snap.core.gpf.OperatorSpi
+++ b/s1tbx-op-insar/src/main/resources/META-INF/services/org.esa.snap.core.gpf.OperatorSpi
@@ -2,7 +2,7 @@ org.esa.s1tbx.insar.gpf.coregistration.CreateStackOp$Spi
 org.esa.s1tbx.insar.gpf.coregistration.CrossCorrelationOp$Spi
 org.esa.s1tbx.insar.gpf.coregistration.WarpOp$Spi
 org.esa.s1tbx.insar.gpf.coregistration.DEMAssistedCoregistrationOp$Spi
-org.esa.s1tbx.insar.gpf.coregistration.OffsetTrackingOp$Spi
+org.esa.s1tbx.insar.gpf.OffsetTrackingOp$Spi
 org.esa.s1tbx.insar.gpf.GoldsteinFilterOp$Spi
 org.esa.s1tbx.insar.gpf.PhaseToElevationOp$Spi
 org.esa.s1tbx.insar.gpf.StackAveragingOp$Spi

--- a/s1tbx-op-ocean-ui/pom.xml
+++ b/s1tbx-op-ocean-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Ocean UI</name>

--- a/s1tbx-op-ocean-ui/pom.xml
+++ b/s1tbx-op-ocean-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <name>S1TBX Ocean UI</name>

--- a/s1tbx-op-ocean-ui/pom.xml
+++ b/s1tbx-op-ocean-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Ocean UI</name>

--- a/s1tbx-op-ocean-ui/pom.xml
+++ b/s1tbx-op-ocean-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Ocean UI</name>

--- a/s1tbx-op-ocean-ui/pom.xml
+++ b/s1tbx-op-ocean-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Ocean UI</name>

--- a/s1tbx-op-ocean-ui/pom.xml
+++ b/s1tbx-op-ocean-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <name>S1TBX Ocean UI</name>

--- a/s1tbx-op-ocean-ui/pom.xml
+++ b/s1tbx-op-ocean-ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <name>S1TBX Ocean UI</name>

--- a/s1tbx-op-sar-processing-ui/pom.xml
+++ b/s1tbx-op-sar-processing-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <artifactId>s1tbx-op-sar-processing-ui</artifactId>

--- a/s1tbx-op-sar-processing-ui/pom.xml
+++ b/s1tbx-op-sar-processing-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-sar-processing-ui</artifactId>

--- a/s1tbx-op-sar-processing-ui/pom.xml
+++ b/s1tbx-op-sar-processing-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-sar-processing-ui</artifactId>

--- a/s1tbx-op-sar-processing-ui/pom.xml
+++ b/s1tbx-op-sar-processing-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-sar-processing-ui</artifactId>

--- a/s1tbx-op-sar-processing-ui/pom.xml
+++ b/s1tbx-op-sar-processing-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-sar-processing-ui</artifactId>

--- a/s1tbx-op-sar-processing-ui/pom.xml
+++ b/s1tbx-op-sar-processing-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <artifactId>s1tbx-op-sar-processing-ui</artifactId>

--- a/s1tbx-op-sar-processing-ui/pom.xml
+++ b/s1tbx-op-sar-processing-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <artifactId>s1tbx-op-sar-processing-ui</artifactId>

--- a/s1tbx-op-sar-processing-ui/src/main/java/org/esa/s1tbx/sar/gpf/ui/orbits/ApplyOrbitFileOpUI.java
+++ b/s1tbx-op-sar-processing-ui/src/main/java/org/esa/s1tbx/sar/gpf/ui/orbits/ApplyOrbitFileOpUI.java
@@ -15,10 +15,10 @@
  */
 package org.esa.s1tbx.sar.gpf.ui.orbits;
 
-import org.esa.s1tbx.io.orbits.DelftOrbitFile;
-import org.esa.s1tbx.io.orbits.DorisOrbitFile;
-import org.esa.s1tbx.io.orbits.PrareOrbitFile;
-import org.esa.s1tbx.io.orbits.SentinelPODOrbitFile;
+import org.esa.s1tbx.io.orbits.delft.DelftOrbitFile;
+import org.esa.s1tbx.io.orbits.doris.DorisOrbitFile;
+import org.esa.s1tbx.io.orbits.prare.PrareOrbitFile;
+import org.esa.s1tbx.io.orbits.sentinel1.SentinelPODOrbitFile;
 import org.esa.snap.core.datamodel.MetadataElement;
 import org.esa.snap.engine_utilities.datamodel.AbstractMetadata;
 import org.esa.snap.graphbuilder.gpf.ui.BaseOperatorUI;

--- a/s1tbx-op-sar-processing/pom.xml
+++ b/s1tbx-op-sar-processing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-sar-processing</artifactId>

--- a/s1tbx-op-sar-processing/pom.xml
+++ b/s1tbx-op-sar-processing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-sar-processing</artifactId>

--- a/s1tbx-op-sar-processing/pom.xml
+++ b/s1tbx-op-sar-processing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-sar-processing</artifactId>

--- a/s1tbx-op-sar-processing/pom.xml
+++ b/s1tbx-op-sar-processing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <artifactId>s1tbx-op-sar-processing</artifactId>

--- a/s1tbx-op-sar-processing/pom.xml
+++ b/s1tbx-op-sar-processing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <artifactId>s1tbx-op-sar-processing</artifactId>

--- a/s1tbx-op-sar-processing/pom.xml
+++ b/s1tbx-op-sar-processing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <artifactId>s1tbx-op-sar-processing</artifactId>

--- a/s1tbx-op-sar-processing/pom.xml
+++ b/s1tbx-op-sar-processing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-sar-processing</artifactId>

--- a/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/DeburstWSSOp.java
+++ b/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/DeburstWSSOp.java
@@ -52,7 +52,7 @@ import java.util.Vector;
  * De-Burst a WSS product
  */
 @OperatorMetadata(alias = "DeburstWSS",
-        category = "Radar",
+        category = "Radar/ENVISAT ASAR",
         authors = "Jun Lu, Luis Veci",
         version = "1.0",
         copyright = "Copyright (C) 2014 by Array Systems Computing Inc.",

--- a/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/filtering/SpeckleFilters/RefinedLee.java
+++ b/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/filtering/SpeckleFilters/RefinedLee.java
@@ -185,15 +185,15 @@ public class RefinedLee implements SpeckleFilter {
      * @return The filtered pixel value.
      */
     private double computePixelValueUsingLocalStatistics(
-            final double[][] neighborPixelValues, final double noDataValue) {
+            final double[][] neighborPixelValues, final Double noDataValue) {
 
-        if (neighborPixelValues[neighborPixelValues.length/2][neighborPixelValues[0].length/2] == noDataValue) {
+        if (noDataValue.equals(neighborPixelValues[neighborPixelValues.length/2][neighborPixelValues[0].length/2])) {
             return noDataValue;
         }
 
         // y is the pixel amplitude or intensity and x is the pixel reflectance before degradation
         final double meanY = getLocalMeanValue(neighborPixelValues, noDataValue);
-        if (meanY == noDataValue) {
+        if (noDataValue.equals(meanY)) {
             return noDataValue;
         }
 
@@ -202,7 +202,7 @@ public class RefinedLee implements SpeckleFilter {
             return meanY;
         }
 
-        if (varY == noDataValue) {
+        if (noDataValue.equals(varY)) {
             return noDataValue;
         }
 

--- a/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/ALOSDeskewingOp.java
+++ b/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/ALOSDeskewingOp.java
@@ -397,8 +397,8 @@ public class ALOSDeskewingOp extends Operator {
                 lon -= 360.0;
             }
 
-            final double alt = dem.getElevation(new GeoPos(lat, lon));
-            if (alt == demNoDataValue) {
+            final Double alt = dem.getElevation(new GeoPos(lat, lon));
+            if (alt.equals(demNoDataValue)) {
                 continue;
             }
 

--- a/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/GeolocationGridGeocodingOp.java
+++ b/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/GeolocationGridGeocodingOp.java
@@ -548,7 +548,7 @@ public final class GeolocationGridGeocodingOp extends Operator {
     public static class ResamplingRaster implements Resampling.Raster {
 
         private final Tile sourceTileI, sourceTileQ;
-        private final double noDataValue;
+        private final Double noDataValue;
         private final ProductData dataBufferI, dataBufferQ;
 
         public ResamplingRaster(final Tile sourceTileI, final Tile sourceTileQ) {
@@ -580,7 +580,7 @@ public final class GeolocationGridGeocodingOp extends Operator {
                 for (int j = 0; j < x.length; j++) {
 
                     double v = dataBufferI.getElemDoubleAt(sourceTileI.getDataBufferIndex(x[j], y[i]));
-                    if (noDataValue != 0 && (v == noDataValue)) {
+                    if (noDataValue != 0 && (noDataValue.equals(v))) {
                         samples[i][j] = noDataValue;
                         allValid = false;
                         continue;
@@ -590,7 +590,7 @@ public final class GeolocationGridGeocodingOp extends Operator {
 
                     if (dataBufferQ != null) {
                         final double vq = dataBufferQ.getElemDoubleAt(sourceTileQ.getDataBufferIndex(x[j], y[i]));
-                        if (noDataValue != 0 && vq == noDataValue) {
+                        if (noDataValue != 0 && noDataValue.equals(vq)) {
                             samples[i][j] = noDataValue;
                             allValid = false;
                             continue;

--- a/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/MosaicOp.java
+++ b/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/MosaicOp.java
@@ -127,6 +127,7 @@ public class MosaicOp extends Operator {
                         " domain mosaic, please select other method");
             }
 
+            Product srcGeoCodingProduct = null;
             GeoCoding srcGeocoding = null;
             for (final Product prod : sourceProduct) {
                 if (prod.getSceneGeoCoding() == null) {
@@ -135,6 +136,7 @@ public class MosaicOp extends Operator {
                 }
                 if (srcGeocoding == null) {
                     srcGeocoding = prod.getSceneGeoCoding();
+                    srcGeoCodingProduct = prod;
                 }
                 // todo check that all source products have same geocoding
 
@@ -167,7 +169,7 @@ public class MosaicOp extends Operator {
             }
 
             targetProduct = new Product("mosaic", "mosaic", sceneWidth, sceneHeight);
-            targetProduct.setSceneGeoCoding(createCRSGeoCoding(srcGeocoding));
+            targetProduct.setSceneGeoCoding(createCRSGeoCoding(srcGeoCodingProduct, srcGeocoding));
 
             // add all bands
             for (Map.Entry<Integer, Band> integerBandEntry : bandIndexSet.entrySet()) {
@@ -219,7 +221,7 @@ public class MosaicOp extends Operator {
         }
     }
 
-    private CrsGeoCoding createCRSGeoCoding(GeoCoding srcGeocoding) throws Exception {
+    private CrsGeoCoding createCRSGeoCoding(final Product srcGeoCodingProduct, final GeoCoding srcGeocoding) throws Exception {
         final CoordinateReferenceSystem srcCRS = srcGeocoding.getMapCRS();
         String wkt;
         try {
@@ -228,7 +230,7 @@ public class MosaicOp extends Operator {
             wkt = srcCRS.toString();
         }
 
-        final CoordinateReferenceSystem targetCRS = CRSGeoCodingHandler.getCRS(wkt);
+        final CoordinateReferenceSystem targetCRS = CRSGeoCodingHandler.getCRS(srcGeoCodingProduct, wkt);
         final double pixelSpacingInDegree = pixelSize / Constants.semiMajorAxis * Constants.RTOD;
 
         double pixelSizeX = pixelSize;

--- a/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/SARSimTerrainCorrectionOp.java
+++ b/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/SARSimTerrainCorrectionOp.java
@@ -973,9 +973,9 @@ public class SARSimTerrainCorrectionOp extends Operator {
 
                     final int index = trgTiles[0].targetTile.getDataBufferIndex(x, y);
 
-                    final double alt = localDEM[yy][x - x0 + 1];
+                    final Double alt = localDEM[yy][x - x0 + 1];
 
-                    if (!useAvgSceneHeight && alt == demNoDataValue) {
+                    if (!useAvgSceneHeight && alt.equals(demNoDataValue)) {
                         if (saveDEM) {
                             demBuffer.setElemDoubleAt(index, demNoDataValue);
                         }

--- a/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/SARSimulationOp.java
+++ b/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/SARSimulationOp.java
@@ -557,7 +557,7 @@ public final class SARSimulationOp extends Operator {
 
                 final double[][] tileDEM = new double[nLat + 1][nLon + 1];
                 final double[][] neighbourDEM = new double[3][3];
-                double alt;
+                Double alt;
 
                 if (saveLayoverShadowMask) {
                     slrs = new double[nLon];
@@ -582,11 +582,11 @@ public final class SARSimulationOp extends Operator {
                             lon -= 360.0;
                         }
                         if (saveZeroHeightSimulation) {
-                            alt = 1;
+                            alt = 1.0;
                         } else {
                             geoPos.setLocation(lat, lon);
                             alt = dem.getElevation(geoPos);
-                            if (alt == demNoDataValue)
+                            if (alt.equals(demNoDataValue))
                                 continue;
                         }
                         tileDEM[i][j] = alt;
@@ -711,9 +711,9 @@ public final class SARSimulationOp extends Operator {
 
                     for (int x = xmin; x < xmax; x++) {
                         final int xx = x - xmin;
-                        double alt = localDEM[yy + 1][xx + 1];
+                        Double alt = localDEM[yy + 1][xx + 1];
 
-                        if (alt == demNoDataValue)
+                        if (alt.equals(demNoDataValue))
                             continue;
 
                         tileGeoRef.getGeoPos(x, y, geoPos);

--- a/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/TerrainFlatteningOp.java
+++ b/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/TerrainFlatteningOp.java
@@ -126,7 +126,7 @@ public final class TerrainFlatteningOp extends Operator {
     private double demNoDataValue = 0; // no data value for DEM
     private SARGeocoding.Orbit orbit = null;
 
-    private double noDataValue = 0;
+    private Double noDataValue = 0.0;
     private double beta0 = 0;
 
     private OrbitStateVector[] orbitStateVectors = null;
@@ -531,8 +531,8 @@ public final class TerrainFlatteningOp extends Operator {
                         final double pixelY = latMaxIdx + i;
                         pix.setLocation(pixelX, pixelY);
                         final GeoPos gp = dem.getGeoPos(pix);
-                        final double alt = dem.getSample(pixelX, pixelY);
-                        if (Double.isNaN(alt) || alt == demNoDataValue)
+                        final Double alt = dem.getSample(pixelX, pixelY);
+                        if (Double.isNaN(alt) || alt.equals(demNoDataValue))
                             continue;
 
                         if (!getPosition(gp.lat, gp.lon, alt, x0, y0, w, h, posData))
@@ -542,7 +542,7 @@ public final class TerrainFlatteningOp extends Operator {
                                 posData.earthPoint, posData.sensorPos);
 
                         gamma0Area[j] = computeGamma0Area(localGeometry, demNoDataValue, noDataValue);
-                        if (gamma0Area[j] == noDataValue)
+                        if (noDataValue.equals(gamma0Area[j]))
                             continue;
 
                         if (outputSigma0) {
@@ -625,8 +625,8 @@ public final class TerrainFlatteningOp extends Operator {
                     for (int x = xmin; x < xmax; x++) {
                         final int xx = x - xmin;
 
-                        double alt = localDEM[yy + 1][xx + 1];
-                        if (alt == demNoDataValue)
+                        Double alt = localDEM[yy + 1][xx + 1];
+                        if (alt.equals(demNoDataValue))
                             continue;
 
                         tileGeoRef.getGeoPos(x, y, geoPos);
@@ -646,7 +646,7 @@ public final class TerrainFlatteningOp extends Operator {
                                 xmin, ymin, x, y, tileGeoRef, localDEM, posData.earthPoint, posData.sensorPos);
 
                         gamma0Area[xx] = computeGamma0Area(localGeometry, demNoDataValue, noDataValue);
-                        if (gamma0Area[xx] == noDataValue)
+                        if (noDataValue.equals(gamma0Area[xx]))
                             continue;
 
                         if (outputSigma0) {
@@ -949,7 +949,7 @@ public final class TerrainFlatteningOp extends Operator {
                 pixPos.setLocation(x, y);
                 targetGeoCoding.getGeoPos(pixPos, geoPos);
                 final double alt = dem.getElevation(geoPos);
-                if (alt == noDataValue)
+                if (noDataValue.equals(alt))
                     continue;
 
                 if (!getPosition(geoPos.lat, geoPos.lon, alt, x0, y0, w, h, posData))
@@ -1081,10 +1081,10 @@ public final class TerrainFlatteningOp extends Operator {
      * @return The computed local illuminated area.
      */
     private static double computeGamma0Area(
-            final LocalGeometry lg, final double demNoDataValue, final double noDataValue) {
+            final LocalGeometry lg, final Double demNoDataValue, final double noDataValue) {
 
-        if (lg.t00Height == demNoDataValue || lg.t01Height == demNoDataValue ||
-                lg.t10Height == demNoDataValue || lg.t11Height == demNoDataValue) {
+        if (demNoDataValue.equals(lg.t00Height) || demNoDataValue.equals(lg.t01Height) ||
+                demNoDataValue.equals(lg.t10Height) || demNoDataValue.equals(lg.t11Height)) {
             return noDataValue;
         }
 
@@ -1134,10 +1134,10 @@ public final class TerrainFlatteningOp extends Operator {
     }
 
     private static double computeSigma0Area(
-            final LocalGeometry lg, final double demNoDataValue, final double noDataValue) {
+            final LocalGeometry lg, final Double demNoDataValue, final double noDataValue) {
 
-        if (lg.t00Height == demNoDataValue || lg.t01Height == demNoDataValue ||
-                lg.t10Height == demNoDataValue || lg.t11Height == demNoDataValue) {
+        if (demNoDataValue.equals(lg.t00Height) || demNoDataValue.equals(lg.t01Height) ||
+                demNoDataValue.equals(lg.t10Height) || demNoDataValue.equals(lg.t11Height)) {
             return noDataValue;
         }
 

--- a/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/UpdateGeoRefOp.java
+++ b/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/geometric/UpdateGeoRefOp.java
@@ -133,7 +133,7 @@ public final class UpdateGeoRefOp extends Operator {
     private OrbitStateVector[] orbitStateVectors = null;
     private AbstractMetadata.SRGRCoefficientList[] srgrConvParams = null;
 
-    private static double noDataValue = -999.0;
+    private static Double noDataValue = -999.0;
     public static String LATITUDE_BAND_NAME = "lat_band";
     public static String LONGITUDE_BAND_NAME = "lon_band";
 
@@ -442,7 +442,7 @@ public final class UpdateGeoRefOp extends Operator {
                 final int nLon = (int) ((lonMax - lonMin) / delLon) + 1;
 
                 final double[][] tileDEM = new double[nLat + 1][nLon + 1];
-                double alt;
+                Double alt;
 
                 for (int i = 0; i < nLat; i++) {
                     final double lat = latMin + i * delLat;
@@ -453,7 +453,7 @@ public final class UpdateGeoRefOp extends Operator {
                         }
                         geoPos.setLocation(lat, lon);
                         alt = dem.getElevation(geoPos);
-                        if (alt == demNoDataValue) {
+                        if (alt.equals(demNoDataValue)) {
                             continue;
                         }
 
@@ -491,9 +491,9 @@ public final class UpdateGeoRefOp extends Operator {
 
                     for (int x = x0; x < xmax; x++) {
                         final int xx = x - x0;
-                        double alt = localDEM[yy + 1][xx + 1];
+                        Double alt = localDEM[yy + 1][xx + 1];
 
-                        if (alt == demNoDataValue) {
+                        if (alt.equals(demNoDataValue)) {
                             continue;
                         }
 
@@ -540,13 +540,13 @@ public final class UpdateGeoRefOp extends Operator {
                     final int xx = x - x0;
                     final int index = trgIndex.getIndex(x);
 
-                    if (latArray[yy][xx] == noDataValue) {
+                    if (noDataValue.equals(latArray[yy][xx])) {
                         latData.setElemDoubleAt(index, fillHole(xx, yy, latArray));
                     } else {
                         latData.setElemDoubleAt(index, latArray[yy][xx]);
                     }
 
-                    if (lonArray[yy][xx] == noDataValue) {
+                    if (noDataValue.equals(lonArray[yy][xx])) {
                         lonData.setElemDoubleAt(index, fillHole(xx, yy, lonArray));
                     } else {
                         lonData.setElemDoubleAt(index, lonArray[yy][xx]);

--- a/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/orbits/ApplyOrbitFileOp.java
+++ b/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/orbits/ApplyOrbitFileOp.java
@@ -257,6 +257,7 @@ public final class ApplyOrbitFileOp extends Operator {
         } catch (Exception e) {
             SystemUtils.LOG.warning(e.getMessage());
             // try other orbit file types
+            boolean tryAnotherType = false;
             for(String type : orbitProvider.getAvailableOrbitTypes()) {
                 if(!orbitType.startsWith(type)) {
                     try {
@@ -264,8 +265,12 @@ public final class ApplyOrbitFileOp extends Operator {
                     } catch (Exception e2) {
                         throw e;
                     }
-                    SystemUtils.LOG.warning("Using "+type+" "+orbitProvider.getOrbitFile()+" instead");
+                    SystemUtils.LOG.warning("Using "+type+' '+orbitProvider.getOrbitFile()+" instead");
+                    tryAnotherType = true;
                 }
+            }
+            if(!tryAnotherType) {
+                throw e;
             }
         }
 

--- a/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/orbits/ApplyOrbitFileOp.java
+++ b/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/orbits/ApplyOrbitFileOp.java
@@ -15,11 +15,11 @@
  */
 package org.esa.s1tbx.sar.gpf.orbits;
 
-import org.esa.s1tbx.io.orbits.DelftOrbitFile;
-import org.esa.s1tbx.io.orbits.DorisOrbitFile;
+import org.esa.s1tbx.io.orbits.delft.DelftOrbitFile;
+import org.esa.s1tbx.io.orbits.doris.DorisOrbitFile;
 import org.esa.s1tbx.io.orbits.OrbitFile;
-import org.esa.s1tbx.io.orbits.PrareOrbitFile;
-import org.esa.s1tbx.io.orbits.SentinelPODOrbitFile;
+import org.esa.s1tbx.io.orbits.prare.PrareOrbitFile;
+import org.esa.s1tbx.io.orbits.sentinel1.SentinelPODOrbitFile;
 import org.esa.snap.core.datamodel.*;
 import org.esa.snap.core.gpf.Operator;
 import org.esa.snap.core.gpf.OperatorException;

--- a/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/orbits/ApplyOrbitFileOp.java
+++ b/s1tbx-op-sar-processing/src/main/java/org/esa/s1tbx/sar/gpf/orbits/ApplyOrbitFileOp.java
@@ -259,7 +259,11 @@ public final class ApplyOrbitFileOp extends Operator {
             // try other orbit file types
             for(String type : orbitProvider.getAvailableOrbitTypes()) {
                 if(!orbitType.startsWith(type)) {
-                    orbitProvider.retrieveOrbitFile(type);
+                    try {
+                        orbitProvider.retrieveOrbitFile(type);
+                    } catch (Exception e2) {
+                        throw e;
+                    }
                     SystemUtils.LOG.warning("Using "+type+" "+orbitProvider.getOrbitFile()+" instead");
                 }
             }

--- a/s1tbx-op-sar-processing/src/test/java/org/esa/s1tbx/sar/gpf/filtering/SpeckleFilterOperatorTest.java
+++ b/s1tbx-op-sar-processing/src/test/java/org/esa/s1tbx/sar/gpf/filtering/SpeckleFilterOperatorTest.java
@@ -45,6 +45,7 @@ public class SpeckleFilterOperatorTest {
     private final static TestProcessor testProcessor = S1TBXTests.createS1TBXTestProcessor();
 
     private String[] productTypeExemptions = {"_BP", "XCA", "WVW", "WVI", "WVS", "WSS", "DOR_VOR_AX"};
+    private String[] exceptionExemptions = {"first be deburst"};
 
     /**
      * Tests Mean speckle filter with a 4-by-4 test product.
@@ -341,6 +342,6 @@ public class SpeckleFilterOperatorTest {
 
     @Test
     public void testProcessAllSentinel1() throws Exception {
-        testProcessor.testProcessAllInPath(spi, S1TBXTests.rootPathsSentinel1, null, null);
+        testProcessor.testProcessAllInPath(spi, S1TBXTests.rootPathsSentinel1, null, exceptionExemptions);
     }
 }

--- a/s1tbx-op-sentinel1-ui/pom.xml
+++ b/s1tbx-op-sentinel1-ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <artifactId>s1tbx-op-sentinel1-ui</artifactId>

--- a/s1tbx-op-sentinel1-ui/pom.xml
+++ b/s1tbx-op-sentinel1-ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-sentinel1-ui</artifactId>

--- a/s1tbx-op-sentinel1-ui/pom.xml
+++ b/s1tbx-op-sentinel1-ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <artifactId>s1tbx-op-sentinel1-ui</artifactId>

--- a/s1tbx-op-sentinel1-ui/pom.xml
+++ b/s1tbx-op-sentinel1-ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <artifactId>s1tbx-op-sentinel1-ui</artifactId>

--- a/s1tbx-op-sentinel1-ui/pom.xml
+++ b/s1tbx-op-sentinel1-ui/pom.xml
@@ -84,6 +84,13 @@
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-modules-javahelp</artifactId>
         </dependency>
+
+
+        <dependency>
+            <groupId>de.sciss</groupId>
+            <artifactId>prefuse-core</artifactId>
+            <version>1.0.1</version>
+        </dependency>
     </dependencies>
     
     <build>

--- a/s1tbx-op-sentinel1-ui/pom.xml
+++ b/s1tbx-op-sentinel1-ui/pom.xml
@@ -47,6 +47,14 @@
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-graph-builder</artifactId>
         </dependency>
+		<dependency>
+            <groupId>org.esa.snap</groupId>
+            <artifactId>ceres-binding</artifactId>
+        </dependency>
+		<dependency>
+            <groupId>org.esa.snap</groupId>
+            <artifactId>ceres-glayer</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>ceres-ui</artifactId>

--- a/s1tbx-op-sentinel1-ui/pom.xml
+++ b/s1tbx-op-sentinel1-ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-sentinel1-ui</artifactId>

--- a/s1tbx-op-sentinel1-ui/pom.xml
+++ b/s1tbx-op-sentinel1-ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-sentinel1-ui</artifactId>

--- a/s1tbx-op-sentinel1-ui/pom.xml
+++ b/s1tbx-op-sentinel1-ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-sentinel1-ui</artifactId>

--- a/s1tbx-op-sentinel1-ui/src/main/java/org/esa/s1tbx/sentinel1/gpf/ui/TOPSARSplitOpUI.java
+++ b/s1tbx-op-sentinel1-ui/src/main/java/org/esa/s1tbx/sentinel1/gpf/ui/TOPSARSplitOpUI.java
@@ -15,7 +15,6 @@
  */
 package org.esa.s1tbx.sentinel1.gpf.ui;
 
-import com.jidesoft.swing.RangeSlider;
 import org.esa.s1tbx.insar.gpf.support.Sentinel1Utils;
 import org.esa.snap.core.datamodel.GeoPos;
 import org.esa.snap.core.datamodel.MetadataElement;
@@ -27,6 +26,7 @@ import org.esa.snap.graphbuilder.gpf.ui.worldmap.NestWorldMapPane;
 import org.esa.snap.graphbuilder.gpf.ui.worldmap.WorldMapUI;
 import org.esa.snap.graphbuilder.rcp.utils.DialogUtils;
 import org.esa.snap.ui.AppContext;
+import prefuse.util.ui.JRangeSlider;
 
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
@@ -46,7 +46,7 @@ public class TOPSARSplitOpUI extends BaseOperatorUI {
     private final JList<String> polList = new JList<>();
 
     private final JLabel burstLabel = new JLabel("");
-    private final RangeSlider burstRange = new RangeSlider(RangeSlider.HORIZONTAL);
+    private final JRangeSlider burstRange = new JRangeSlider(0,0,0,0, JRangeSlider.HORIZONTAL);
     private final Map<String, Integer> swathBurstsMap = new HashMap<>();
 
     private final WorldMapUI worldMapUI = new WorldMapUI();
@@ -73,7 +73,6 @@ public class TOPSARSplitOpUI extends BaseOperatorUI {
 
         burstRange.setMinimum(1);
         burstRange.setMaximum(9999);
-        burstRange.setMajorTickSpacing(1);
 
         burstRange.addChangeListener(new ChangeListener() {
             @Override

--- a/s1tbx-op-sentinel1-ui/src/main/resources/org/esa/s1tbx/sentinel1/docs/operators/AzimuthShiftOp.html
+++ b/s1tbx-op-sentinel1-ui/src/main/resources/org/esa/s1tbx/sentinel1/docs/operators/AzimuthShiftOp.html
@@ -17,7 +17,7 @@
 </tbody>
 </table>
 <h3>Sentinel-1 Azimuth Shift</h3>
-<p class="MsoNormal"><span>This opaerator follows the Range Shift
+<p class="MsoNormal"><span>This operator follows the Range Shift
 operator in the TOPS InSAR processing chain. It first estimates a
 global azimuth offset for the whole sub-swath of the split S-1 SLC
 image using a Enhanced Spectral Diversity (ESD) method. The ESD

--- a/s1tbx-op-sentinel1-ui/src/main/resources/org/esa/s1tbx/sentinel1/docs/operators/BackGeocodingOp.html
+++ b/s1tbx-op-sentinel1-ui/src/main/resources/org/esa/s1tbx/sentinel1/docs/operators/BackGeocodingOp.html
@@ -21,7 +21,7 @@
 </tbody>
 </table>
 <h3>Sentinel-1 Back Geocoding</h3>
-<p class="MsoNormal"><span>This opaerator co-registers two S-1 SLC
+<p class="MsoNormal"><span>This operator co-registers two S-1 SLC
 split products (master and slave) of the same sub-swath using the
 orbits of the two products and a Digital Elevation Model
 (DEM).<br>

--- a/s1tbx-op-sentinel1-ui/src/main/resources/org/esa/s1tbx/sentinel1/docs/operators/RangeShiftOp.html
+++ b/s1tbx-op-sentinel1-ui/src/main/resources/org/esa/s1tbx/sentinel1/docs/operators/RangeShiftOp.html
@@ -18,7 +18,7 @@
 </tbody>
 </table>
 <h3>Sentinel-1 Range Shift</h3>
-<p class="MsoNormal"><span>This opaerator follows the Backgeocoding
+<p class="MsoNormal"><span>This operator follows the Backgeocoding
 operator in the TOPS InSAR processing chain. It first estimates a
 constant range offset for the whole sub-swath of the split S-1 SLC
 image using incoherent cross-correlation. The estimation is done for

--- a/s1tbx-op-sentinel1-ui/src/main/resources/org/esa/s1tbx/sentinel1/docs/operators/SpectralDiversityOp.html
+++ b/s1tbx-op-sentinel1-ui/src/main/resources/org/esa/s1tbx/sentinel1/docs/operators/SpectralDiversityOp.html
@@ -18,7 +18,7 @@
 </table>
 <h3>Sentinel-1 Enhanced Spectral Diversity<br>
 </h3>
-<p class="MsoNormal"><span>This opaerator follows the Backgeocoding
+<p class="MsoNormal"><span>This operator follows the Backgeocoding
 operator in the TOPS InSAR processing chain. It first estimates a
 constant range offset for the whole sub-swath of the split S-1 SLC
 image using incoherent cross-correlation. The estimation is done for

--- a/s1tbx-op-sentinel1/pom.xml
+++ b/s1tbx-op-sentinel1/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-sentinel1</artifactId>

--- a/s1tbx-op-sentinel1/pom.xml
+++ b/s1tbx-op-sentinel1/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <artifactId>s1tbx-op-sentinel1</artifactId>

--- a/s1tbx-op-sentinel1/pom.xml
+++ b/s1tbx-op-sentinel1/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-sentinel1</artifactId>

--- a/s1tbx-op-sentinel1/pom.xml
+++ b/s1tbx-op-sentinel1/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <artifactId>s1tbx-op-sentinel1</artifactId>

--- a/s1tbx-op-sentinel1/pom.xml
+++ b/s1tbx-op-sentinel1/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <artifactId>s1tbx-op-sentinel1</artifactId>

--- a/s1tbx-op-sentinel1/pom.xml
+++ b/s1tbx-op-sentinel1/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-sentinel1</artifactId>

--- a/s1tbx-op-sentinel1/pom.xml
+++ b/s1tbx-op-sentinel1/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-sentinel1</artifactId>

--- a/s1tbx-op-sentinel1/src/main/java/org/esa/s1tbx/sentinel1/gpf/BackGeocodingOp.java
+++ b/s1tbx-op-sentinel1/src/main/java/org/esa/s1tbx/sentinel1/gpf/BackGeocodingOp.java
@@ -65,6 +65,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -225,7 +227,17 @@ public final class BackGeocodingOp extends Operator {
 
             createTargetProduct();
 
-            StackUtils.saveMasterProductBandNames(targetProduct, masterProduct.getBandNames());
+            List<String> masterProductBands = new ArrayList<>();
+            String mstSuffix = StackUtils.MST + StackUtils.createBandTimeStamp(masterProduct);
+            for (String bandName : masterProduct.getBandNames()) {
+                if (masterProduct.getBand(bandName) instanceof VirtualBand) {
+                    continue;
+                }
+                masterProductBands.add(bandName + mstSuffix);
+            }
+
+            StackUtils.saveMasterProductBandNames(targetProduct,
+                    masterProductBands.toArray(new String[masterProductBands.size()]));
             StackUtils.saveSlaveProductNames(sourceProduct, targetProduct,
                     masterProduct, targetBandToSlaveBandMap);
 

--- a/s1tbx-op-sentinel1/src/main/java/org/esa/s1tbx/sentinel1/gpf/BackGeocodingOp.java
+++ b/s1tbx-op-sentinel1/src/main/java/org/esa/s1tbx/sentinel1/gpf/BackGeocodingOp.java
@@ -759,7 +759,7 @@ public final class BackGeocodingOp extends Operator {
             return;
         }
 
-        final double[][] derampDemodPhase = computeDerampDemodPhase(subSwathIndex, sBurstIndex, sourceRectangle);
+        final double[][] derampDemodPhase = sSU.computeDerampDemodPhase(sSubSwath, subSwathIndex, sBurstIndex, sourceRectangle);
 
         if (derampDemodPhase == null) {
             return;
@@ -1089,47 +1089,6 @@ public final class BackGeocodingOp extends Operator {
         }
 
         return new Rectangle(minX, minY, maxX - minX + 1, maxY - minY + 1);
-    }
-
-    /**
-     * Compute combined deramp and demodulation phase for area in slave image defined by rectangle.
-     * @param subSwathIndex Sub-swath index
-     * @param sBurstIndex Burst index
-     * @param rectangle Rectangle that defines the area in slave image
-     * @return The combined deramp and demodulation phase
-     */
-    private double[][] computeDerampDemodPhase(
-            final int subSwathIndex, final int sBurstIndex, final Rectangle rectangle) {
-
-        try {
-            final int x0 = rectangle.x;
-            final int y0 = rectangle.y;
-            final int w = rectangle.width;
-            final int h = rectangle.height;
-            final int xMax = x0 + w;
-            final int yMax = y0 + h;
-            final int s = subSwathIndex - 1;
-
-            final double[][] phase = new double[h][w];
-            final int firstLineInBurst = sBurstIndex*sSubSwath[s].linesPerBurst;
-            for (int y = y0; y < yMax; y++) {
-                final int yy = y - y0;
-                final double ta = (y - firstLineInBurst)*sSubSwath[s].azimuthTimeInterval;
-                for (int x = x0; x < xMax; x++) {
-                    final int xx = x - x0;
-                    final double kt = sSubSwath[s].dopplerRate[sBurstIndex][x];
-                    final double deramp = -Constants.PI * kt * FastMath.pow(ta - sSubSwath[s].referenceTime[sBurstIndex][x], 2);
-                    final double demod = -Constants.TWO_PI * sSubSwath[s].dopplerCentroid[sBurstIndex][x] * ta;
-                    phase[yy][xx] = deramp + demod;
-                }
-            }
-
-            return phase;
-        } catch (Throwable e) {
-            OperatorUtils.catchOperatorException("computeDerampDemodPhase", e);
-        }
-
-        return null;
     }
 
     public static void performDerampDemod(final Tile slaveTileI, final Tile slaveTileQ,

--- a/s1tbx-op-sentinel1/src/main/java/org/esa/s1tbx/sentinel1/gpf/BackGeocodingOp.java
+++ b/s1tbx-op-sentinel1/src/main/java/org/esa/s1tbx/sentinel1/gpf/BackGeocodingOp.java
@@ -547,8 +547,8 @@ public final class BackGeocodingOp extends Operator {
                 for (int j = 0; j < w; j++) {
                     final double lat = mSubSwath[subSwathIndex - 1].latitude[i][j];
                     final double lon = mSubSwath[subSwathIndex - 1].longitude[i][j];
-                    final double alt = dem.getElevation(new GeoPos(lat, lon));
-                    if (alt == demNoDataValue) {
+                    final Double alt = dem.getElevation(new GeoPos(lat, lon));
+                    if (alt.equals(demNoDataValue)) {
                         continue;
                     }
                     GeoUtils.geo2xyzWGS84(lat, lon, alt, earthPoint);
@@ -647,9 +647,9 @@ public final class BackGeocodingOp extends Operator {
                 final double lat = mSU.getLatitude(azTime, rgTime, subSwathIndex);
                 final double lon = mSU.getLongitude(azTime, rgTime, subSwathIndex);
                 geoPos.setLocation(lat, lon);
-                double alt = dem.getElevation(geoPos);
-                if (alt == demNoDataValue) {
-                    alt = egm.getEGM(lat, lon);
+                Double alt = dem.getElevation(geoPos);
+                if (alt.equals(demNoDataValue)) {
+                    alt = (double)egm.getEGM(lat, lon);
                 }
 
                 GeoUtils.geo2xyzWGS84(geoPos.getLat(), geoPos.getLon(), alt, posData.earthPoint);
@@ -845,12 +845,12 @@ public final class BackGeocodingOp extends Operator {
                     lat[l][p] = gp.lat;
                     lon[l][p] = gp.lon;
 
-                    double alt = dem.getElevation(gp);
-                    if (alt == demNoDataValue && !maskOutAreaWithoutElevation) { // get corrected elevation for 0
-                        alt = egm.getEGM(gp.lat, gp.lon);
+                    Double alt = dem.getElevation(gp);
+                    if (alt.equals(demNoDataValue) && !maskOutAreaWithoutElevation) { // get corrected elevation for 0
+                        alt = (double)egm.getEGM(gp.lat, gp.lon);
                     }
 
-                    if (alt != demNoDataValue) {
+                    if (!alt.equals(demNoDataValue)) {
                         GeoUtils.geo2xyzWGS84(gp.lat, gp.lon, alt, posData.earthPoint);
                         if(getPosition(subSwathIndex, mBurstIndex, mSU, mOrbit, posData)) {
 
@@ -903,7 +903,7 @@ public final class BackGeocodingOp extends Operator {
                     tileWindow, rgAzRatio, 1, 1, invalidIndex, 0);
 
             boolean allElementsAreNull = true;
-            double alt = 0;
+            Double alt;
             for(int yy = 0; yy < h; yy++) {
                 for (int xx = 0; xx < w; xx++) {
                     if (rgArray[yy][xx] == invalidIndex || azArray[yy][xx] == invalidIndex) {
@@ -914,7 +914,7 @@ public final class BackGeocodingOp extends Operator {
                             if(elevation != null) {
                                 elevation[yy][xx] = alt;
                             }
-                            if (alt != demNoDataValue) {
+                            if (!alt.equals(demNoDataValue)) {
                                 slavePixelPos[yy][xx] = new PixelPos(rgArray[yy][xx], azArray[yy][xx]);
                                 allElementsAreNull = false;
                             } else {

--- a/s1tbx-op-sentinel1/src/main/java/org/esa/s1tbx/sentinel1/gpf/RangeShiftOp.java
+++ b/s1tbx-op-sentinel1/src/main/java/org/esa/s1tbx/sentinel1/gpf/RangeShiftOp.java
@@ -102,7 +102,7 @@ public class RangeShiftOp extends Operator {
     private boolean isRangeOffsetAvailable = false;
     private double azOffset = 0.0;
     private double rgOffset = 0.0;
-    private double noDataValue = -9999.0;
+    private Double noDataValue = -9999.0;
     private Sentinel1Utils.SubSwathInfo[] subSwath = null;
     private int subSwathIndex = 0;
     private String[] subSwathNames = null;
@@ -417,7 +417,7 @@ public class RangeShiftOp extends Operator {
                 //SystemUtils.LOG.info("RangeShiftOp: burst = " + burstIndexArray.get(i) + ", azimuth offset = " + azShift);
                 //SystemUtils.LOG.info("RangeShiftOp: burst = " + burstIndexArray.get(i) + ", range offset = " + rgShift);
 
-                if (azShift == noDataValue || rgShift == noDataValue) {
+                if (noDataValue.equals(azShift) || noDataValue.equals(rgShift)) {
                     continue;
                 }
 

--- a/s1tbx-op-sentinel1/src/main/java/org/esa/s1tbx/sentinel1/gpf/SpectralDiversityOp.java
+++ b/s1tbx-op-sentinel1/src/main/java/org/esa/s1tbx/sentinel1/gpf/SpectralDiversityOp.java
@@ -131,7 +131,7 @@ public class SpectralDiversityOp extends Operator {
     private boolean isAzimuthOffsetAvailable = false;
     private double azOffset = 0.0;
     private double rgOffset = 0.0;
-    private double noDataValue = -9999.0;
+    private Double noDataValue = -9999.0;
     private Sentinel1Utils su;
     private Sentinel1Utils.SubSwathInfo[] subSwath = null;
     private int subSwathIndex = 0;
@@ -388,7 +388,7 @@ public class SpectralDiversityOp extends Operator {
                 SystemUtils.LOG.fine("RangeShiftOp: burst = " + burstIndexArray.get(i) + ", range offset = " + rgShift
                                              + ", azimuth offset = " + azShift);
 
-                if (azShift == noDataValue || rgShift == noDataValue) {
+                if (noDataValue.equals(azShift) || noDataValue.equals(rgShift)) {
                     continue;
                 }
 

--- a/s1tbx-op-sentinel1/src/main/java/org/esa/s1tbx/sentinel1/gpf/SpectralDiversityOp.java
+++ b/s1tbx-op-sentinel1/src/main/java/org/esa/s1tbx/sentinel1/gpf/SpectralDiversityOp.java
@@ -427,17 +427,18 @@ public class SpectralDiversityOp extends Operator {
             }
 
             if (count > 0) {
-                azOffset = sumAzOffset / (double)count;
+                //azOffset = sumAzOffset / (double)count;
                 rgOffset = sumRgOffset / (double)count;
             } else {
-                throw new OperatorException("estimateOffset failed.");
+                rgOffset = 0.0;
+                SystemUtils.LOG.warning("RangeShiftOp: Cross-correlation failed for all bursts, set range shift to 0");
             }
 
             saveOverallRangeShift(rgOffset);
 
             saveRangeShiftPerBurst(rgOffsetArray, burstIndexArray);
 
-            SystemUtils.LOG.fine("RangeShiftOp: whole image azimuth offset = " + azOffset);
+            //SystemUtils.LOG.fine("RangeShiftOp: whole image azimuth offset = " + azOffset);
             SystemUtils.LOG.fine("RangeShiftOp: Overall range shift = " + rgOffset);
 
         } catch (Throwable e) {

--- a/s1tbx-op-sentinel1/src/main/java/org/esa/s1tbx/sentinel1/gpf/TOPSARDeburstOp.java
+++ b/s1tbx-op-sentinel1/src/main/java/org/esa/s1tbx/sentinel1/gpf/TOPSARDeburstOp.java
@@ -47,6 +47,7 @@ import org.esa.snap.engine_utilities.gpf.TileIndex;
 import org.esa.snap.engine_utilities.util.Maths;
 
 import java.awt.Rectangle;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -412,7 +413,7 @@ public final class TOPSARDeburstOp extends Operator {
     /**
      * Update target product metadata.
      */
-    private void updateTargetProductMetadata() {
+    private void updateTargetProductMetadata() throws IOException {
 
         updateAbstractMetadata();
         updateOriginalMetadata();
@@ -565,7 +566,7 @@ public final class TOPSARDeburstOp extends Operator {
         return pointElem;
     }
 
-    private void updateOriginalMetadata() {
+    private void updateOriginalMetadata() throws IOException {
 
         updateSwathTiming();
 
@@ -604,11 +605,17 @@ public final class TOPSARDeburstOp extends Operator {
         return "S1"+mission.substring(mission.length()-1, mission.length());
     }
 
-    private void updateCalibrationVector() {
+    private void updateCalibrationVector() throws IOException {
 
         final String[] selectedPols = Sentinel1Utils.getProductPolarizations(absRoot);
-        final MetadataElement srcCalibration = AbstractMetadata.getOriginalProductMetadata(sourceProduct).
-                getElement("calibration");
+        final MetadataElement origMeta = AbstractMetadata.getOriginalProductMetadata(sourceProduct);
+        if(origMeta == null) {
+            throw new IOException("Original product metadata not found");
+        }
+        final MetadataElement srcCalibration = origMeta.getElement("calibration");
+        if(srcCalibration == null) {
+            throw new IOException("Calibration element not found in Original product metadata");
+        }
         final MetadataElement bandCalibration = srcCalibration.getElementAt(0).getElement("calibration");
 
         final String missionPrefix = getMissionPrefix(absRoot).toLowerCase();

--- a/s1tbx-op-sentinel1/src/main/java/org/esa/s1tbx/sentinel1/gpf/TOPSARMergeOp.java
+++ b/s1tbx-op-sentinel1/src/main/java/org/esa/s1tbx/sentinel1/gpf/TOPSARMergeOp.java
@@ -555,11 +555,14 @@ public final class TOPSARMergeOp extends Operator {
                 }
             }
             MetadataElement targetSlaveMetadataRoot = AbstractMetadata.getSlaveMetadata(targetProduct.getMetadataRoot());
-            targetSlaveMetadataRoot.setAttributeString(AbstractMetadata.MASTER_BANDS,
-                    String.join(" ", masterProductBands.toArray(new String[masterProductBands.size()])));
-            targetSlaveMetadataRoot.getElementAt(0).setAttributeString(AbstractMetadata.SLAVE_BANDS,
-                    String.join(" ", slaveProductBands.toArray(new String[slaveProductBands.size()])));
-
+            if(!masterProductBands.isEmpty()) {
+                targetSlaveMetadataRoot.setAttributeString(AbstractMetadata.MASTER_BANDS,
+                        String.join(" ", masterProductBands.toArray(new String[masterProductBands.size()])));
+            }
+            if(!slaveProductBands.isEmpty()) {
+                targetSlaveMetadataRoot.getElementAt(0).setAttributeString(AbstractMetadata.SLAVE_BANDS,
+                        String.join(" ", slaveProductBands.toArray(new String[slaveProductBands.size()])));
+            }
         }
     }
 

--- a/s1tbx-op-utilities-ui/pom.xml
+++ b/s1tbx-op-utilities-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-utilities-ui</artifactId>

--- a/s1tbx-op-utilities-ui/pom.xml
+++ b/s1tbx-op-utilities-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <artifactId>s1tbx-op-utilities-ui</artifactId>

--- a/s1tbx-op-utilities-ui/pom.xml
+++ b/s1tbx-op-utilities-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <artifactId>s1tbx-op-utilities-ui</artifactId>

--- a/s1tbx-op-utilities-ui/pom.xml
+++ b/s1tbx-op-utilities-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <artifactId>s1tbx-op-utilities-ui</artifactId>

--- a/s1tbx-op-utilities-ui/pom.xml
+++ b/s1tbx-op-utilities-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-utilities-ui</artifactId>

--- a/s1tbx-op-utilities-ui/pom.xml
+++ b/s1tbx-op-utilities-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-utilities-ui</artifactId>

--- a/s1tbx-op-utilities-ui/pom.xml
+++ b/s1tbx-op-utilities-ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-utilities-ui</artifactId>

--- a/s1tbx-op-utilities/pom.xml
+++ b/s1tbx-op-utilities/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-utilities</artifactId>

--- a/s1tbx-op-utilities/pom.xml
+++ b/s1tbx-op-utilities/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-utilities</artifactId>

--- a/s1tbx-op-utilities/pom.xml
+++ b/s1tbx-op-utilities/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-utilities</artifactId>

--- a/s1tbx-op-utilities/pom.xml
+++ b/s1tbx-op-utilities/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <artifactId>s1tbx-op-utilities</artifactId>

--- a/s1tbx-op-utilities/pom.xml
+++ b/s1tbx-op-utilities/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <artifactId>s1tbx-op-utilities</artifactId>

--- a/s1tbx-op-utilities/pom.xml
+++ b/s1tbx-op-utilities/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <artifactId>s1tbx-op-utilities</artifactId>

--- a/s1tbx-op-utilities/pom.xml
+++ b/s1tbx-op-utilities/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>s1tbx-op-utilities</artifactId>

--- a/s1tbx-rcp/pom.xml
+++ b/s1tbx-rcp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <name>S1TBX Rich Client Platform</name>

--- a/s1tbx-rcp/pom.xml
+++ b/s1tbx-rcp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Rich Client Platform</name>

--- a/s1tbx-rcp/pom.xml
+++ b/s1tbx-rcp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Rich Client Platform</name>

--- a/s1tbx-rcp/pom.xml
+++ b/s1tbx-rcp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <name>S1TBX Rich Client Platform</name>

--- a/s1tbx-rcp/pom.xml
+++ b/s1tbx-rcp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Rich Client Platform</name>

--- a/s1tbx-rcp/pom.xml
+++ b/s1tbx-rcp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <name>S1TBX Rich Client Platform</name>

--- a/s1tbx-rcp/pom.xml
+++ b/s1tbx-rcp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.esa.s1tbx</groupId>
         <artifactId>s1tbx</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <name>S1TBX Rich Client Platform</name>


### PR DESCRIPTION
Updates in support of the ESA ALOS-IPF products. All IPF products are presented in zero-Doppler format and currently omit (have blank) all processing facility data records: Modifications entail:
- recognition of product origin (ESA/JAXA)
- access to image data record headers via PDR as opposed to SDR header structures, for IPF products
- generation of accurate (msec) product start/stop times from the product PDR/SDR headers
- for IPF products, access to additional CEOS fields, in particular the image range to slant range cubic polynomial coefficients
- accurate georeferencing 
- correction to abstracted metadata range bandwidth units (JAXA use kHz) 

The zip file unzips to a folder "s1tbx-io-updates" - contents should be transferred to overwrite s1tbx entries.
[s1tbx-io-updates.zip](https://github.com/senbox-org/s1tbx/files/1028989/s1tbx-io-updates.zip)

