### PR TITLE
remove dependency on jlinda

### DIFF
--- a/s1tbx-io/pom.xml
+++ b/s1tbx-io/pom.xml
@@ -60,12 +60,13 @@
             <artifactId>s1tbx-commons</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jlinda</groupId>
-            <artifactId>jlinda-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>23.0</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>


### PR DESCRIPTION
s1tbx-io doesn't need a dependency on JLinda - replace with only dep on Guava