### PR TITLE
Fix determination of degree crs

### DIFF
--- a/s1tbx-commons/src/main/java/org/esa/s1tbx/commons/CRSGeoCodingHandler.java
+++ b/s1tbx-commons/src/main/java/org/esa/s1tbx/commons/CRSGeoCodingHandler.java
@@ -24,6 +24,7 @@ import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
+import javax.measure.unit.NonSI;
 import java.awt.geom.Rectangle2D;
 
 /**
@@ -58,7 +59,7 @@ public class CRSGeoCodingHandler {
 
         double pixelSizeX = pixelSpacingInMeter;
         double pixelSizeY = pixelSpacingInMeter;
-        if (targetCRS.getName().getCode().equals("WGS84(DD)")) {
+        if (targetCRS.getCoordinateSystem().getAxis(0).getUnit().equals(NonSI.DEGREE_ANGLE)) {
             pixelSizeX = pixelSpacingInDegree;
             pixelSizeY = pixelSpacingInDegree;
         }


### PR DESCRIPTION
This makes pixel spacing with degrees more robust by comparing the actual (first) axis unit instead of the coordinate system name.