### PR TITLE
Fixes for reading Sentinel-1 products from AWS

### DIFF
--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/sentinel1/Sentinel1Level1Directory.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/sentinel1/Sentinel1Level1Directory.java
@@ -49,6 +49,7 @@ import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
 import java.awt.Dimension;
 import java.io.*;
+import java.nio.file.Files;
 import java.text.DateFormat;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -233,7 +234,7 @@ public class Sentinel1Level1Directory extends XMLProductDirectory implements Sen
             try {
                 final File productInfoFile = productDir.getFile("productInfo.json");
                 if(productInfoFile.length() > 0) {
-                    final BufferedReader streamReader = new BufferedReader(new FileReader(productInfoFile.getPath()));
+                    final BufferedReader streamReader = new BufferedReader(new InputStreamReader(Files.newInputStream(productInfoFile.toPath())));
                     final JSONParser parser = new JSONParser();
                     final JSONObject json = (JSONObject) parser.parse(streamReader);
                     json.remove("filenameMap");

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/sentinel1/Sentinel1ProductReaderPlugIn.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/sentinel1/Sentinel1ProductReaderPlugIn.java
@@ -37,6 +37,18 @@ public class Sentinel1ProductReaderPlugIn implements ProductReaderPlugIn {
     private static String[] annotation_prefixes = new String[] {"s1", "s2-", "s3-", "s4-", "s5-", "s6-", "iw", "ew", "rs2", "asa"};
 
     /**
+     * Gets the file for the given relative path.
+     *
+     * @param path The base file.
+     * @param subpath The relative file or directory path.
+     * @return Gets the file or directory for the specified file path.
+     */    
+    private static File getFile(final File path, final String subpath) {
+        File child = path.toPath().resolve(subpath).toFile();
+        return child;
+    }
+
+    /**
      * Checks whether the given object is an acceptable input for this product reader and if so, the method checks if it
      * is capable of decoding the input's content.
      *
@@ -47,7 +59,7 @@ public class Sentinel1ProductReaderPlugIn implements ProductReaderPlugIn {
         File file = ReaderUtils.getFileFromInput(input);
         if (file != null) {
             if(file.isDirectory()) {
-                file = new File(file, Sentinel1Constants.PRODUCT_HEADER_NAME);
+                file = getFile(file, Sentinel1Constants.PRODUCT_HEADER_NAME);
                 if(!file.exists()) {
                     return DecodeQualification.UNABLE;
                 }
@@ -64,7 +76,7 @@ public class Sentinel1ProductReaderPlugIn implements ProductReaderPlugIn {
                 return DecodeQualification.INTENDED;
             }
             if(filename.startsWith("s1") && filename.endsWith(".safe") && file.isDirectory()) {
-                File manifest = new File(file, Sentinel1Constants.PRODUCT_HEADER_NAME);
+                File manifest = getFile(file, Sentinel1Constants.PRODUCT_HEADER_NAME);
                 if(manifest.exists()) {
                     if (isLevel1(manifest) || isLevel2(manifest) || isLevel0(manifest)) {
                         return DecodeQualification.INTENDED;
@@ -86,7 +98,7 @@ public class Sentinel1ProductReaderPlugIn implements ProductReaderPlugIn {
             return name.contains("_1AS") || name.contains("_1AD") || name.contains("_1SS") || name.contains("_1SD");
         } else {
             final File baseFolder = file.getParentFile();
-            final File annotationFolder = new File(baseFolder, ANNOTATION);
+            final File annotationFolder = getFile(baseFolder, ANNOTATION);
             return annotationFolder.exists() && checkFolder(annotationFolder, ".xml");
         }
     }
@@ -96,7 +108,7 @@ public class Sentinel1ProductReaderPlugIn implements ProductReaderPlugIn {
             return ZipUtils.findInZip(file, "s1", ".nc");
         } else {
             final File baseFolder = file.getParentFile();
-            final File measurementFolder = new File(baseFolder, MEASUREMENT);
+            final File measurementFolder = getFile(baseFolder, MEASUREMENT);
             return measurementFolder.exists() && checkFolder(measurementFolder, ".nc");
         }
     }
@@ -117,7 +129,7 @@ public class Sentinel1ProductReaderPlugIn implements ProductReaderPlugIn {
             }
         } else {
             final File baseFolder = file.getParentFile();
-            final File annotationFolder = new File(baseFolder, ANNOTATION);
+            final File annotationFolder = getFile(baseFolder, ANNOTATION);
             if (!annotationFolder.exists()) {
                 throw new IOException("annotation folder is missing in product");
             }


### PR DESCRIPTION
This commit does some changes to allow to SNAP to load Sentinel-1 products from the [S1 AWS bucket](https://sentinel-s1-l1c.s3.amazonaws.com).

There is a commit related in [snap-engine ](https://github.com/senbox-org/snap-engine/pull/150) repo to properly work.
It is based in 7.x branch.
