### PR TITLE
Uniforming menu entries

### DIFF
--- a/jlinda/jlinda-nest/src/main/java/org/jlinda/nest/gpf/AzimuthFilterOp.java
+++ b/jlinda/jlinda-nest/src/main/java/org/jlinda/nest/gpf/AzimuthFilterOp.java
@@ -32,7 +32,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 @OperatorMetadata(alias = "AzimuthFilter",
-        category = "Radar/Interferometric/Filtering",
+        category = "Radar/Interferometric/Filtering/Spectral Filtering",
         authors = "Petar Marinkovic",
         version = "1.0",
         copyright = "Copyright (C) 2013 by PPO.labs",

--- a/jlinda/jlinda-nest/src/main/java/org/jlinda/nest/gpf/RangeFilterOp.java
+++ b/jlinda/jlinda-nest/src/main/java/org/jlinda/nest/gpf/RangeFilterOp.java
@@ -31,7 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @OperatorMetadata(alias = "RangeFilter",
-        category = "Radar/Interferometric/Filtering",
+        category = "Radar/Interferometric/Filtering/Spectral Filtering",
         authors = "Petar Marinkovic",
         version = "1.0",
         copyright = "Copyright (C) 2013 by PPO.labs",


### PR DESCRIPTION
I am trying to uniform the Graph Builder menus with the main window menus, to do so the category in the operator descriptor must be the same as the one in the main menu. 