### PR TITLE
TestDEM fix

### DIFF
--- a/s1tbx-op-sar-processing/pom.xml
+++ b/s1tbx-op-sar-processing/pom.xml
@@ -77,6 +77,13 @@
             <artifactId>snap-smart-configurator</artifactId>
             <version>${snap.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.esa.snap</groupId>
+            <artifactId>snap-test-utils</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/s1tbx-op-sar-processing/src/test/java/org/esa/s1tbx/sar/gpf/geometric/TestDEM.java
+++ b/s1tbx-op-sar-processing/src/test/java/org/esa/s1tbx/sar/gpf/geometric/TestDEM.java
@@ -9,7 +9,9 @@ import org.esa.snap.core.datamodel.Product;
 import org.esa.snap.core.gpf.OperatorSpi;
 import org.esa.snap.dem.gpf.AddElevationOp;
 import org.esa.snap.engine_utilities.util.TestUtils;
+import org.esa.snap.test.LongTestRunner;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -17,6 +19,7 @@ import static org.junit.Assert.assertNotNull;
 /**
  * Created by lveci on 24/10/2014.
  */
+@RunWith(LongTestRunner.class)
 public class TestDEM {
 
     private final static OperatorSpi spi = new AddElevationOp.Spi();

--- a/s1tbx-op-sar-processing/src/test/java/org/esa/s1tbx/sar/gpf/geometric/TestDEM.java
+++ b/s1tbx-op-sar-processing/src/test/java/org/esa/s1tbx/sar/gpf/geometric/TestDEM.java
@@ -1,21 +1,18 @@
 package org.esa.s1tbx.sar.gpf.geometric;
 
 import com.bc.ceres.core.ProgressMonitor;
-import org.esa.s1tbx.commons.test.S1TBXTests;
-import org.esa.s1tbx.commons.test.TestData;
-import org.esa.snap.core.datamodel.*;
+import org.esa.snap.core.datamodel.Band;
+import org.esa.snap.core.datamodel.GeoCoding;
+import org.esa.snap.core.datamodel.GeoPos;
+import org.esa.snap.core.datamodel.PixelPos;
+import org.esa.snap.core.datamodel.Product;
 import org.esa.snap.core.gpf.OperatorSpi;
 import org.esa.snap.dem.gpf.AddElevationOp;
-import org.esa.snap.engine_utilities.gpf.TestProcessor;
 import org.esa.snap.engine_utilities.util.TestUtils;
 import org.junit.Test;
 
-import java.io.File;
-import java.util.Arrays;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Created by lveci on 24/10/2014.
@@ -48,6 +45,7 @@ public class TestDEM {
 
         // get targetProduct: execute initialize()
         final Product targetProduct = op.getTargetProduct();
+        op.doExecute(ProgressMonitor.NULL);
         TestUtils.verifyProduct(targetProduct, true, true, true);
 
         final Band elevBand = targetProduct.getBand("elevation");


### PR DESCRIPTION
It was necessary to call the doExecute in this test.
Also, I also marked the test as long-running one, because of the download of the DEM.