### PR TITLE
get rid of ejml lib v0.34 from gt-referencing

### DIFF
--- a/jlinda/jlinda-core/pom.xml
+++ b/jlinda/jlinda-core/pom.xml
@@ -59,11 +59,6 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.4</version>
         </dependency>
-        <dependency>
-            <groupId>org.ejml</groupId>
-            <artifactId>ejml-ddense</artifactId>
-            <version>0.39</version>
-        </dependency>
     </dependencies>
     
     <build>


### PR DESCRIPTION
This should remove ejml library v0.34 from the classpath which is pulled in as transitive dependency from gt-referencing.
There is also a necessary PR for snap-engine.
Luis, can you try if this still works for s1tbx?