### PR TITLE
removed dependency to guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -428,12 +428,6 @@
                 <version>3.6.1</version>
             </dependency>
 
-			<dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>23.0</version>
-            </dependency>
-
             <!-- Jama Matrix Algebra Library ############################################# -->
 
             <dependency>

--- a/s1tbx-io-ephemeris/pom.xml
+++ b/s1tbx-io-ephemeris/pom.xml
@@ -36,11 +36,6 @@
             <artifactId>s1tbx-commons</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>23.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
         </dependency>

--- a/s1tbx-io/pom.xml
+++ b/s1tbx-io/pom.xml
@@ -60,11 +60,6 @@
             <artifactId>commons-math3</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>23.0</version>
-        </dependency>
-        <dependency>
             <groupId>uk.me.jstott</groupId>
             <artifactId>jcoord</artifactId>
             <version>1.0</version>

--- a/s1tbx-op-sentinel1/pom.xml
+++ b/s1tbx-op-sentinel1/pom.xml
@@ -72,11 +72,6 @@
             <version>${s1tbx.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>23.0</version>
-        </dependency>
     </dependencies>
     
     <build>


### PR DESCRIPTION
Hi,
we extended the public packages in snap-core
from 
                        <publicPackage>com.google.common.primitives.*</publicPackage>
to
                        <publicPackage>com.google.common.*</publicPackage>
We needed the packages in another module.
Now S1TBX has doesn't know where to load the com.google.common.collect.BiMap from.

Solution to this is to remove the declared dependency in s1tbx and use the one from snap-core.
A quick test I performed worked. Is this change okay for you?