### PR TITLE
Fix for reading TPG of ALOS

### DIFF
--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/ceos/alos/AlosPalsarProductReader.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/ceos/alos/AlosPalsarProductReader.java
@@ -26,7 +26,7 @@ import org.esa.snap.core.datamodel.ProductData;
 import org.esa.snap.core.datamodel.TiePointGrid;
 import org.esa.snap.engine_utilities.datamodel.Unit;
 
-import java.io.File;
+import java.awt.Rectangle;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -72,7 +72,8 @@ public class AlosPalsarProductReader extends CEOSProductReader {
                                            final ProductData destBuffer, final ProgressMonitor pm)
             throws IOException {
         final AlosPalsarProductDirectory alosDataDir = (AlosPalsarProductDirectory) this.dataDir;
-        alosDataDir.readTiePointGridRasterData(tpg, destBuffer, pm);
+        Rectangle destRect = new Rectangle(destOffsetX, destOffsetY, destWidth, destHeight);
+        alosDataDir.readTiePointGridRasterData(tpg, destRect, destBuffer, pm);
     }
 
     /**

--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/ceos/alos2/Alos2ProductReader.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/ceos/alos2/Alos2ProductReader.java
@@ -30,6 +30,7 @@ import org.esa.snap.core.datamodel.TiePointGrid;
 import org.esa.snap.core.datamodel.quicklooks.Quicklook;
 import org.esa.snap.engine_utilities.datamodel.Unit;
 
+import java.awt.Rectangle;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -89,7 +90,8 @@ public class Alos2ProductReader extends CEOSProductReader {
                                            final ProductData destBuffer, final ProgressMonitor pm)
             throws IOException {
         final Alos2ProductDirectory alosDataDir = (Alos2ProductDirectory) this.dataDir;
-        alosDataDir.readTiePointGridRasterData(tpg, destBuffer, pm);
+        Rectangle destRect = new Rectangle(destOffsetX, destOffsetY, destWidth, destHeight);
+        alosDataDir.readTiePointGridRasterData(tpg, destRect, destBuffer, pm);
     }
 
     /**


### PR DESCRIPTION
The fix is necessary because the method `AlosPalsarProductDirectory.readTiePointGridRasterData()` did always read the full TPG data even though only a subset was requested.
The subset region wasn't forwarded from `Alos2ProductReader.readTiePointGridRasterData()` and `AlosPalsarProductReader.readTiePointGridRasterData()`.
This was no problem till now because always the whole TPG was requested. Now when a subset is created only the necessary region is requested.

