### PR TITLE
Overflow issue when calculating size of ImageIOFile

### DIFF
--- a/s1tbx-commons/src/main/java/org/esa/s1tbx/commons/io/ImageIOFile.java
+++ b/s1tbx-commons/src/main/java/org/esa/s1tbx/commons/io/ImageIOFile.java
@@ -337,7 +337,7 @@ public class ImageIOFile {
 
     public static ImageInputStream createImageInputStream(final InputStream inStream, final Dimension bandDimensions) throws IOException {
         final long freeMemory = Runtime.getRuntime().freeMemory() / 1024 / 1024;
-        final long size = (bandDimensions.width*bandDimensions.height *32L) / 1024 / 1024;
+        final long size = bandDimensions.width / 1024 * bandDimensions.height /1024 * 32L;
         if(useFileCache || freeMemory < 100L || size > 15000L) {
             SystemUtils.LOG.info("Using FileCacheImageInputStream");
             return new FileCacheImageInputStream(inStream, createCacheDir());

--- a/s1tbx-commons/src/test/java/org/esa/s1tbx/commons/io/ImageIOFileTest.java
+++ b/s1tbx-commons/src/test/java/org/esa/s1tbx/commons/io/ImageIOFileTest.java
@@ -1,0 +1,20 @@
+package org.esa.s1tbx.commons.io;
+
+import java.awt.Dimension;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import javax.imageio.stream.FileCacheImageInputStream;
+import javax.imageio.stream.ImageInputStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ImageIOFileTest {
+
+  @Test
+  public void createImageInputStreamForLargeDimension() throws IOException {
+    ImageInputStream imageInputStream = ImageIOFile.createImageInputStream(new ByteArrayInputStream(new byte[0]), new Dimension(60000, 60000));
+    Assert.assertTrue("For large files we expect a FileCacheImageInputStream", imageInputStream instanceof FileCacheImageInputStream);
+  }
+}


### PR DESCRIPTION
With the current implementation bandDimensions.width * bandDimensions.heigth can become larger than Long.MAX_VALUE and overflow to a negative value. Because of this, the MemoryCacheImageInputStream is used instead of the FileCacheImageInputStream.