### PR TITLE
The units of power components for MF3CF and MF4CF are changed

### DIFF
--- a/rstb/rstb-op-polarimetric-tools/src/main/java/org/csa/rstb/polarimetric/gpf/decompositions/MF3CF.java
+++ b/rstb/rstb-op-polarimetric-tools/src/main/java/org/csa/rstb/polarimetric/gpf/decompositions/MF3CF.java
@@ -71,7 +71,7 @@ public class MF3CF extends DecompositionBase implements Decomposition, QuadPolPr
      * @param targetBand     the new target band
      */
     public void setBandUnit(final String targetBandName, final Band targetBand) {
-        targetBand.setUnit(Unit.INTENSITY_DB);
+        targetBand.setUnit(Unit.INTENSITY);
     }
 
     /**

--- a/rstb/rstb-op-polarimetric-tools/src/main/java/org/csa/rstb/polarimetric/gpf/decompositions/MF4CF.java
+++ b/rstb/rstb-op-polarimetric-tools/src/main/java/org/csa/rstb/polarimetric/gpf/decompositions/MF4CF.java
@@ -71,7 +71,7 @@ public class MF4CF extends DecompositionBase implements Decomposition, QuadPolPr
      * @param targetBand     the new target band
      */
     public void setBandUnit(final String targetBandName, final Band targetBand) {
-        targetBand.setUnit(Unit.INTENSITY_DB);
+        targetBand.setUnit(Unit.INTENSITY);
     }
 
     /**


### PR DESCRIPTION
Hello Luis,
Hope you are doing well!

There was a minor mistake in the units of MF3CF and MF4CF power components. The units were in 'DB' in the previous code. However, in actuality, the computed power components are on a linear scale in the MF3CF.java and MF4CF.java files. Hence, I have modified the units from 'INTENSITY_DB' to only 'INTENSITY'. 

Please let me know if any further clarifications are needed.

Thanks and best regards,
Subhadip