### PR TITLE
Fix for incorrect data type in Sentinel-1 GRD images

### DIFF
--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/sentinel1/Sentinel1Level1Directory.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/sentinel1/Sentinel1Level1Directory.java
@@ -180,7 +180,7 @@ public class Sentinel1Level1Directory extends XMLProductDirectory implements Sen
                 } else {
                     for (int b = 0; b < img.getNumBands(); ++b) {
                         bandName = "Amplitude" + '_' + suffix;
-                        final Band band = new Band(bandName, ProductData.TYPE_INT16, width, height);
+                        final Band band = new Band(bandName, ProductData.TYPE_UINT16, width, height);
                         band.setUnit(Unit.AMPLITUDE);
                         band.setNoDataValueUsed(true);
                         band.setNoDataValue(NoDataValue);


### PR DESCRIPTION
Fixed a bug where GRD data was read as `int16` instead of `uint16` as is specified in the Sentinel-1 Product specification. The bug resulted in high intensity values (above 2**15) being reported as negative.