### PR TITLE
Use system proxy settings for downloading orbit files

### DIFF
--- a/s1tbx-cloud/src/main/java/org/esa/s1tbx/cloud/opensearch/OpenSearch.java
+++ b/s1tbx-cloud/src/main/java/org/esa/s1tbx/cloud/opensearch/OpenSearch.java
@@ -53,6 +53,9 @@ public class OpenSearch {
             client.setConnectionManagerTimeout(TIMEOUT);
             client.setSocketTimeout(TIMEOUT);
             client.setMaxConnectionsPerHost(2);
+            if (System.getProperty("https.proxyHost") != null) {
+                client.setProxy(System.getProperty("https.proxyHost"),System.getProperty("https_proxyPort"));
+            }
 
             client.addCredentials(host, null, null,
                                   new UsernamePasswordCredentials(userName, password));

--- a/s1tbx-cloud/src/main/java/org/esa/s1tbx/cloud/opensearch/OpenSearch.java
+++ b/s1tbx-cloud/src/main/java/org/esa/s1tbx/cloud/opensearch/OpenSearch.java
@@ -54,7 +54,8 @@ public class OpenSearch {
             client.setSocketTimeout(TIMEOUT);
             client.setMaxConnectionsPerHost(2);
             if (System.getProperty("https.proxyHost") != null) {
-                client.setProxy(System.getProperty("https.proxyHost"),System.getProperty("https_proxyPort"));
+                client.setProxy(System.getProperty("https.proxyHost"),
+				Integer.parseInt(System.getProperty("https_proxyPort")));
             }
 
             client.addCredentials(host, null, null,


### PR DESCRIPTION
Since my company uses a corporate proxy, I had to set system environments variables (https.proxyPort and https.proxyHost) so JAVA programs as gpt can use it, but since s1tbx uses Apache abdera http client, and that client not uses these env vaiables, we must manually set the proxy through the setProxy function,

Here are some posts of people having the same issue as me : 
https://forum.step.esa.int/t/apply-orbit-file-thrugh-corporative-proxy/18636/22
https://forum.step.esa.int/t/unable-to-download-orbit-file/30867