### PR TITLE
fix: Apply-Orbit-File "Sentinel Precise (Autodownload)" is converted to "Sentinel Restituted"

### DIFF
--- a/s1tbx-io-ephemeris/src/main/java/org/esa/s1tbx/orbits/io/sentinel1/GnssOrbitFileDownloader.java
+++ b/s1tbx-io-ephemeris/src/main/java/org/esa/s1tbx/orbits/io/sentinel1/GnssOrbitFileDownloader.java
@@ -114,16 +114,13 @@ public class GnssOrbitFileDownloader {
     }
 
     private static String convertOrbitType(final String orbitType) throws Exception {
-        switch (orbitType) {
-            case RESORB:
-            case SentinelPODOrbitFile.RESTITUTED:
-                return RESORB;
-            case POEORB:
-            case SentinelPODOrbitFile.PRECISE:
-                return POEORB;
-            default:
-                throw new Exception("Unsupported orbit type " + orbitType);
+        if (orbitType.startsWith(RESORB) || orbitType.startsWith(SentinelPODOrbitFile.RESTITUTED)) {
+            return RESORB;
         }
+        if (orbitType.startsWith(POEORB) || orbitType.startsWith(SentinelPODOrbitFile.PRECISE)) {
+            return POEORB;
+        }
+        throw new Exception("Unsupported orbit type " + orbitType);
     }
 
     private static String convertMissionPrefix(final String missionPrefix) throws Exception {


### PR DESCRIPTION
https://forum.step.esa.int/t/no-valid-orbit-file-found-with-sentinel-precise-but-with-restituted-even-though-they-are-no-longer-available/34184