### PR TITLE
fix: Coherence crashes if slvProduct is null

### DIFF
--- a/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/CoherenceOp.java
+++ b/s1tbx-op-insar/src/main/java/org/esa/s1tbx/insar/gpf/CoherenceOp.java
@@ -29,6 +29,7 @@ import org.esa.snap.core.gpf.annotations.OperatorMetadata;
 import org.esa.snap.core.gpf.annotations.Parameter;
 import org.esa.snap.core.gpf.annotations.SourceProduct;
 import org.esa.snap.core.gpf.annotations.TargetProduct;
+import org.esa.snap.core.util.SystemUtils;
 import org.esa.snap.core.util.ProductUtils;
 import org.esa.snap.dem.dataio.DEMFactory;
 import org.esa.snap.dem.dataio.FileElevationModel;
@@ -436,6 +437,10 @@ public class CoherenceOp extends Operator {
 
                 if (singleMaster) {
                     String slvProductName = StackUtils.findOriginalSlaveProductName(sourceProduct, container.sourceSlave.realBand);
+                    if (slvProductName == null){
+                        SystemUtils.LOG.warning("createTargetProduct: slvProductName is null");
+                        continue;
+                    }
                     StackUtils.saveSlaveProductBandNames(targetProduct, slvProductName,
                             targetBandNames.toArray(new String[0]));
                 }


### PR DESCRIPTION
To fix the “software regression” (commit: 7759322509 (“update StackUtils and add test”, 2021-04-08) on snap-engine)

See discussion : https://forum.step.esa.int/t/software-regression-nodeid-coherence-slvproductname-is-null/34286

It’s a little bit ugly, but it works.
