### PR TITLE
Replace floating point assertions with epsilon-check

### DIFF
--- a/s1tbx-io/src/main/java/org/esa/s1tbx/io/gaofen3/Gaofen3ProductDirectory.java
+++ b/s1tbx-io/src/main/java/org/esa/s1tbx/io/gaofen3/Gaofen3ProductDirectory.java
@@ -427,8 +427,8 @@ public class Gaofen3ProductDirectory extends XMLProductDirectory  {
                 // Sanity check:
                 PixelPos _idx = new PixelPos();
                 geocoding.getPixelPos(geoRPC, _idx);
-                assert idx.x == _idx.x;
-                assert idx.y == _idx.y;
+                assert Math.abs(idx.x - _idx.x) < 0.001;
+                assert Math.abs(idx.y - _idx.y) < 0.001;
             }
 
             // Initiate Jacobian and residual:


### PR DESCRIPTION
There assertions are doing direct comparison of floating point numbers, which is almost never correct. This is breaking some of our unit tests as a result.