### PR TITLE
Disable the default builds report generation function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -580,7 +580,7 @@
 						<!--  to test from the command line mvn test -DskipTests=false -->
                         <skipTests>${skipTests}</skipTests>
                         <printSummary>true</printSummary>
-						<disableXmlReport>false</disableXmlReport>
+						<disableXmlReport>true</disableXmlReport>
 						<redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <excludes>
                             <exclude>**/TestRaster.java</exclude>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
