### PR TITLE
Fixed overlapping text in CalibrationOpUI

### DIFF
--- a/s1tbx-op-calibration-ui/src/main/java/org/esa/s1tbx/calibration/gpf/ui/CalibrationOpUI.java
+++ b/s1tbx-op-calibration-ui/src/main/java/org/esa/s1tbx/calibration/gpf/ui/CalibrationOpUI.java
@@ -227,47 +227,12 @@ public class CalibrationOpUI extends BaseOperatorUI {
                 outputBetaBandCheckBox.setVisible(false);
                 outputDNBandCheckBox.setVisible(false);
 
+                saveInComplexCheckBox.setSelected(false);
+
                 if (sampleType.equals("COMPLEX")) {
-
                     saveInComplexCheckBox.setEnabled(true);
-                    saveInComplexCheckBox.setSelected(false);
-
-                    if (saveInComplex) {
-                        saveInDbCheckBox.setEnabled(false);
-                        createGamma0VirtualBandCheckBox.setEnabled(false);
-                        createBeta0VirtualBandCheckBox.setEnabled(false);
-                        saveInDbCheckBox.setSelected(false);
-                        createGamma0VirtualBandCheckBox.setSelected(false);
-                        createBeta0VirtualBandCheckBox.setSelected(false);
-
-                        outputSigmaBandCheckBox.setEnabled(false);
-                        outputGammaBandCheckBox.setEnabled(false);
-                        outputBetaBandCheckBox.setEnabled(false);
-                        outputDNBandCheckBox.setEnabled(false);
-                        outputSigmaBandCheckBox.setSelected(false);
-                        outputGammaBandCheckBox.setSelected(false);
-                        outputBetaBandCheckBox.setSelected(false);
-                        outputDNBandCheckBox.setSelected(false);
-
-                    } else {
-                        saveInDbCheckBox.setEnabled(true);
-                        createGamma0VirtualBandCheckBox.setEnabled(true);
-                        createBeta0VirtualBandCheckBox.setEnabled(true);
-
-                        outputSigmaBandCheckBox.setVisible(true);
-                        outputGammaBandCheckBox.setVisible(true);
-                        outputBetaBandCheckBox.setVisible(true);
-                        outputDNBandCheckBox.setVisible(true);
-                    }
-
                 } else {
                     saveInComplexCheckBox.setEnabled(false);
-                    saveInComplexCheckBox.setSelected(false);
-
-                    outputSigmaBandCheckBox.setVisible(true);
-                    outputGammaBandCheckBox.setVisible(true);
-                    outputBetaBandCheckBox.setVisible(true);
-                    outputDNBandCheckBox.setVisible(true);
                 }
 
                 if (mission.startsWith("SENTINEL-1")) {
@@ -275,13 +240,16 @@ public class CalibrationOpUI extends BaseOperatorUI {
                     OperatorUIUtils.initParamList(polList, Sentinel1Utils.getProductPolarizations(absRoot),
                             (String[]) paramMap.get("selectedPolarisations"));
 
-                    DialogUtils.enableComponents(auxFileLabel, auxFile, false);
-                    DialogUtils.enableComponents(externalAuxFileLabel, externalAuxFile, false);
+
                     DialogUtils.enableComponents(bandListLabel, bandListPane, false);
                     saveInDbCheckBox.setVisible(false);
                     createGamma0VirtualBandCheckBox.setVisible(false);
                     createBeta0VirtualBandCheckBox.setVisible(false);
                     DialogUtils.enableComponents(polListLabel, polListPane, true);
+                    outputSigmaBandCheckBox.setVisible(true);
+                    outputGammaBandCheckBox.setVisible(true);
+                    outputBetaBandCheckBox.setVisible(true);
+                    outputDNBandCheckBox.setVisible(true);
                 }
             }
 


### PR DESCRIPTION
Fixed a problem where some checkboxes were overlapping in the CalibrationOpUI on mac. Also removed some unreachable code and refactored unnecessarily complicated functions. Removed an inconsistency where the EVISAT Auxiliary File option was made invisible when the product was S-1, and visible but disabled for any other non-ENVISAT product.

Non-S1, non-complex
<img width="463" alt="image" src="https://user-images.githubusercontent.com/118947197/222522441-de42fe1f-b7d1-4230-88ba-524bb41206c9.png">

S1, non-complex
<img width="462" alt="image" src="https://user-images.githubusercontent.com/118947197/222523581-0bbb9a96-c0c2-4278-ae12-2987be3bd567.png">

Non-S1, complex
<img width="463" alt="image" src="https://user-images.githubusercontent.com/118947197/222523685-ac8a0258-7b9c-475c-a3ac-127bacbfab91.png">

S1, complex
<img width="462" alt="image" src="https://user-images.githubusercontent.com/118947197/222523827-0d36d79e-160f-41ec-9f6b-99dc6d497b2b.png">
