### PR TITLE
fix ICEYE processor version parsing

### DIFF
--- a/snap_iceye_reader/src/main/java/com/iceye/esa/snap/dataio/IceyeSLCProductReader.java
+++ b/snap_iceye_reader/src/main/java/com/iceye/esa/snap/dataio/IceyeSLCProductReader.java
@@ -269,7 +269,7 @@ public class IceyeSLCProductReader extends SARReader {
             AbstractMetadata.setAttribute(absRoot, AbstractMetadata.PROC_TIME, ProductData.UTC.parse(netcdfFile.getRootGroup().findVariable(IceyeXConstants.PROC_TIME_UTC).readScalarString(), standardDateFormat));
 
 
-            AbstractMetadata.setAttribute(absRoot, AbstractMetadata.ProcessingSystemIdentifier, IceyeXConstants.ICEYE_PROCESSOR_NAME_PREFIX + netcdfFile.getRootGroup().findVariable(IceyeXConstants.PROCESSING_SYSTEM_IDENTIFIER).readScalarFloat());
+            AbstractMetadata.setAttribute(absRoot, AbstractMetadata.ProcessingSystemIdentifier, IceyeXConstants.ICEYE_PROCESSOR_NAME_PREFIX + netcdfFile.getRootGroup().findVariable(IceyeXConstants.PROCESSING_SYSTEM_IDENTIFIER).readScalarString());
             AbstractMetadata.setAttribute(absRoot, AbstractMetadata.CYCLE, netcdfFile.getRootGroup().findVariable(IceyeXConstants.CYCLE).readScalarInt());
             AbstractMetadata.setAttribute(absRoot, AbstractMetadata.REL_ORBIT, netcdfFile.getRootGroup().findVariable(IceyeXConstants.REL_ORBIT).readScalarInt());
             AbstractMetadata.setAttribute(absRoot, AbstractMetadata.ABS_ORBIT, netcdfFile.getRootGroup().findVariable(IceyeXConstants.ABS_ORBIT).readScalarInt());


### PR DESCRIPTION
The ICEYE product reader tried to parse the processor version number as a float, causing problems with bigger version numbers. Parsing the version number as a string should fix the problem.